### PR TITLE
リスナーの一部実装

### DIFF
--- a/plugin/src/main/java/net/okocraft/box/plugin/Box.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/Box.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 
 public final class Box extends JavaPlugin {
@@ -114,6 +115,12 @@ public final class Box extends JavaPlugin {
 
     public void debug(@NotNull String log) {
         // TODO
+    }
+
+    @NotNull
+    public ExecutorService getExecutor() {
+        // TODO
+        return null;
     }
 
     private void loadConfig() {

--- a/plugin/src/main/java/net/okocraft/box/plugin/Box.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/Box.java
@@ -112,6 +112,10 @@ public final class Box extends JavaPlugin {
         return soundPlayer;
     }
 
+    public void debug(@NotNull String log) {
+        // TODO
+    }
+
     private void loadConfig() {
         generalConfig = new GeneralConfig(this);
 

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/AbstractListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/AbstractListener.java
@@ -1,0 +1,23 @@
+package net.okocraft.box.plugin.listener;
+
+import net.okocraft.box.plugin.Box;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractListener implements Listener {
+
+    protected final Box plugin;
+
+    public AbstractListener(@NotNull Box plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start() {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void shutdown() {
+        HandlerList.unregisterAll(this);
+    }
+}

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
@@ -1,0 +1,48 @@
+package net.okocraft.box.plugin.listener;
+
+import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.model.User;
+import net.okocraft.box.plugin.model.item.Item;
+import net.okocraft.box.plugin.sound.BoxSound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+public class ItemPickupListener extends AbstractListener {
+
+    public ItemPickupListener(@NotNull Box plugin) {
+        super(plugin);
+    }
+
+    @EventHandler
+    public void onItemPickup(@NotNull EntityPickupItemEvent e) {
+        if (!(e.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) e.getEntity();
+
+        if (plugin.getGeneralConfig().getDisabledWorlds().contains(player.getWorld().getName())) {
+            return;
+        }
+
+        Optional<Item> item = plugin.getItemManager().getItem(e.getItem().getItemStack());
+
+        if (item.isEmpty()) {
+            return;
+        }
+
+        User user = plugin.getUserManager().getUser(player.getUniqueId());
+
+        if (user.isAutoStore(item.get())) {
+            user.increase(item.get());
+            e.setCancelled(true);
+            plugin.getSoundPlayer().play(player, BoxSound.ITEM_DEPOSIT);
+
+            // TODO アクションバーにアイテム所持数表示 (要検討)
+        }
+    }
+}

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
@@ -6,6 +6,7 @@ import net.okocraft.box.plugin.model.item.Item;
 import net.okocraft.box.plugin.sound.BoxSound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,7 @@ public class ItemPickupListener extends AbstractListener {
         super(plugin);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemPickup(@NotNull EntityPickupItemEvent e) {
         if (!(e.getEntity() instanceof Player)) {
             return;

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/PlayerConnectionListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/PlayerConnectionListener.java
@@ -1,0 +1,51 @@
+package net.okocraft.box.plugin.listener;
+
+import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.model.User;
+import net.okocraft.box.plugin.model.manager.UserManager;
+import net.okocraft.box.plugin.result.UserCheckResult;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class PlayerConnectionListener extends AbstractListener {
+
+    public PlayerConnectionListener(@NotNull Box plugin) {
+        super(plugin);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPreLogin(@NotNull AsyncPlayerPreLoginEvent e) {
+        if (e.getLoginResult() != AsyncPlayerPreLoginEvent.Result.ALLOWED) {
+            return;
+        }
+
+        UserCheckResult checkResult = plugin.getUserManager().checkUser(e.getUniqueId(), e.getName());
+        plugin.debug("User " + e.getName() + " (" + e.getUniqueId().toString() + ") check result: " + checkResult);
+    }
+
+
+    @EventHandler
+    public void onJoin(@NotNull PlayerJoinEvent e) {
+        plugin.getExecutor().submit(() -> plugin.getUserManager().loadUser(e.getPlayer().getUniqueId()));
+    }
+
+    @EventHandler
+    public void onQuit(@NotNull PlayerQuitEvent e) {
+        plugin.getExecutor().submit(() -> {
+            UserManager userManager = plugin.getUserManager();
+            UUID uuid = e.getPlayer().getUniqueId();
+
+            if (userManager.isLoaded(uuid)) {
+                User user = userManager.getUser(e.getPlayer().getUniqueId());
+                userManager.saveUser(user);
+                userManager.unloadUser(user);
+            }
+        });
+    }
+}

--- a/plugin/src/main/java/net/okocraft/box/plugin/model/manager/UserManager.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/model/manager/UserManager.java
@@ -43,9 +43,13 @@ public class UserManager {
             throw new IllegalStateException("Could not save user:" + user.getName(), e);
         }
     }
-    
+
     public void unloadUser(@NotNull User user) {
         loadedUser.remove(user);
+    }
+
+    public boolean isLoaded(@NotNull UUID uuid) {
+        return loadedUser.stream().anyMatch(u -> u.getUuid().equals(uuid));
     }
 
     @NotNull

--- a/plugin/src/main/java/net/okocraft/box/plugin/model/manager/UserManager.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/model/manager/UserManager.java
@@ -43,6 +43,10 @@ public class UserManager {
             throw new IllegalStateException("Could not save user:" + user.getName(), e);
         }
     }
+    
+    public void unloadUser(@NotNull User user) {
+        loadedUser.remove(user);
+    }
 
     @NotNull
     public UserCheckResult checkUser(@NotNull UUID uuid, @NotNull String name) {

--- a/plugin/src/main/java/net/okocraft/box/plugin/model/manager/UserManager.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/model/manager/UserManager.java
@@ -5,11 +5,15 @@ import net.okocraft.box.plugin.model.User;
 import net.okocraft.box.plugin.result.UserCheckResult;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public class UserManager {
 
     private final Box plugin;
+    private final Set<User> loadedUser = new HashSet<>();
 
     public UserManager(@NotNull Box plugin) {
         this.plugin = plugin;
@@ -18,10 +22,18 @@ public class UserManager {
     @NotNull
     public User loadUser(@NotNull UUID uuid) {
         try {
-            return plugin.getStorage().loadUser(uuid).join();
+            User user = plugin.getStorage().loadUser(uuid).join();
+            loadedUser.add(user);
+            return user;
         } catch (Throwable e) {
             throw new IllegalStateException("Could not load user:" + uuid.toString(), e);
         }
+    }
+
+    @NotNull
+    public User getUser(@NotNull UUID uuid) {
+        Optional<User> user = loadedUser.stream().filter(u -> u.getUuid().equals(uuid)).findFirst();
+        return user.orElseGet(() -> loadUser(uuid));
     }
 
     public void saveUser(@NotNull User user) {


### PR DESCRIPTION
- Box のリスナーは `AbstractListener` を拡張する。
- プレイヤーの参加・退出リスナーと、アイテムのピックアップリスナーのみ実装している。
- 他のリスナーの実装は別のブランチで行う。