### PR TITLE
権限の列挙クラス

### DIFF
--- a/plugin/src/main/java/net/okocraft/box/plugin/BoxPermission.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/BoxPermission.java
@@ -4,6 +4,13 @@ import org.jetbrains.annotations.NotNull;
 
 public enum BoxPermission {
 
+    BOX_AUTO_STORE("box.autostore", true),
+
+    BOX_STICK_BREAK("box.stick.break", true),
+    BOX_STICK_CONSUME("box.stick.consume", true),
+    BOX_STICK_OPEN("box.stick.open", true),
+    BOX_STICK_PLACE("box.stick.place", true),
+    BOX_STICK_THROW("box.stick.throw", true)
     ;
 
     private final String node;

--- a/plugin/src/main/java/net/okocraft/box/plugin/BoxPermission.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/BoxPermission.java
@@ -1,0 +1,25 @@
+package net.okocraft.box.plugin;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum BoxPermission {
+
+    ;
+
+    private final String node;
+    private final boolean def;
+
+    BoxPermission(@NotNull String node, boolean def) {
+        this.node = node;
+        this.def = def;
+    }
+
+    @NotNull
+    public String getNode() {
+        return node;
+    }
+
+    public boolean isDefault() {
+        return def;
+    }
+}

--- a/plugin/src/main/java/net/okocraft/box/plugin/BoxPermission.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/BoxPermission.java
@@ -1,6 +1,16 @@
 package net.okocraft.box.plugin;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.bukkit.permissions.Permissible;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public enum BoxPermission {
 
@@ -10,8 +20,9 @@ public enum BoxPermission {
     BOX_STICK_CONSUME("box.stick.consume", true),
     BOX_STICK_OPEN("box.stick.open", true),
     BOX_STICK_PLACE("box.stick.place", true),
-    BOX_STICK_THROW("box.stick.throw", true)
-    ;
+    BOX_STICK_THROW("box.stick.throw", true);
+    private final static LoadingCache<BoxPermission, Permission> CACHE =
+            CacheBuilder.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).build(CacheLoader.from(BoxPermission::getPermission));
 
     private final String node;
     private final boolean def;
@@ -28,5 +39,20 @@ public enum BoxPermission {
 
     public boolean isDefault() {
         return def;
+    }
+
+    public boolean has(@NotNull Permissible permissible) {
+        try {
+            return permissible.hasPermission(CACHE.get(this));
+        } catch (ExecutionException e) {
+            return permissible.hasPermission(getNode());
+        }
+    }
+
+    @Contract(" -> new")
+    @NotNull
+    public Permission getPermission() {
+        PermissionDefault def = isDefault() ? PermissionDefault.TRUE : PermissionDefault.OP;
+        return new Permission(getNode(), def);
     }
 }

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
@@ -1,6 +1,7 @@
 package net.okocraft.box.plugin.listener;
 
 import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.BoxPermission;
 import net.okocraft.box.plugin.model.User;
 import net.okocraft.box.plugin.model.item.Item;
 import net.okocraft.box.plugin.sound.BoxSound;
@@ -25,6 +26,10 @@ public class ItemPickupListener extends AbstractListener {
         }
 
         Player player = (Player) e.getEntity();
+
+        if (!player.hasPermission(BoxPermission.BOX_AUTO_STORE.getNode())) {
+            return;
+        }
 
         if (plugin.getGeneralConfig().getDisabledWorlds().contains(player.getWorld().getName())) {
             return;

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/ItemPickupListener.java
@@ -21,15 +21,11 @@ public class ItemPickupListener extends AbstractListener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemPickup(@NotNull EntityPickupItemEvent e) {
-        if (!(e.getEntity() instanceof Player)) {
+        if (!(e.getEntity() instanceof Player) || !BoxPermission.BOX_AUTO_STORE.has(e.getEntity())) {
             return;
         }
 
         Player player = (Player) e.getEntity();
-
-        if (!player.hasPermission(BoxPermission.BOX_AUTO_STORE.getNode())) {
-            return;
-        }
 
         if (plugin.getGeneralConfig().getDisabledWorlds().contains(player.getWorld().getName())) {
             return;

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/BlockPlaceListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/BlockPlaceListener.java
@@ -1,6 +1,7 @@
 package net.okocraft.box.plugin.listener.stick;
 
 import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.BoxPermission;
 import net.okocraft.box.plugin.model.User;
 import net.okocraft.box.plugin.model.item.Item;
 import org.bukkit.event.EventHandler;
@@ -19,12 +20,12 @@ public class BlockPlaceListener extends AbstractStickListener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPlace(@NotNull BlockPlaceEvent e) {
         if (isInDisabledWorld(e.getPlayer())
+                || isCreative(e.getPlayer())
                 || !hasStick(e.getPlayer(), false)
-                || isCreative(e.getPlayer())) {
+                || !e.getPlayer().hasPermission(BoxPermission.BOX_STICK_PLACE.getNode())
+        ) {
             return;
         }
-
-        // TODO: 権限チェック
 
         Optional<Item> item = plugin.getItemManager().getItem(e.getItemInHand());
 

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/BlockPlaceListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/BlockPlaceListener.java
@@ -22,7 +22,7 @@ public class BlockPlaceListener extends AbstractStickListener {
         if (isInDisabledWorld(e.getPlayer())
                 || isCreative(e.getPlayer())
                 || !hasStick(e.getPlayer(), false)
-                || !e.getPlayer().hasPermission(BoxPermission.BOX_STICK_PLACE.getNode())
+                || !BoxPermission.BOX_STICK_PLACE.has(e.getPlayer())
         ) {
             return;
         }

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemBreakListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemBreakListener.java
@@ -1,6 +1,7 @@
 package net.okocraft.box.plugin.listener.stick;
 
 import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.BoxPermission;
 import net.okocraft.box.plugin.model.User;
 import net.okocraft.box.plugin.model.item.Item;
 import org.bukkit.event.EventHandler;
@@ -22,8 +23,10 @@ public class ItemBreakListener extends AbstractStickListener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemBreak(@NotNull PlayerItemBreakEvent e) {
         if (isInDisabledWorld(e.getPlayer())
+                || isCreative(e.getPlayer())
                 || !hasStick(e.getPlayer(), false)
-                || isCreative(e.getPlayer())) {
+                || !e.getPlayer().hasPermission(BoxPermission.BOX_STICK_BREAK.getNode())
+        ) {
             return;
         }
 

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemBreakListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemBreakListener.java
@@ -25,7 +25,7 @@ public class ItemBreakListener extends AbstractStickListener {
         if (isInDisabledWorld(e.getPlayer())
                 || isCreative(e.getPlayer())
                 || !hasStick(e.getPlayer(), false)
-                || !e.getPlayer().hasPermission(BoxPermission.BOX_STICK_BREAK.getNode())
+                || !BoxPermission.BOX_STICK_BREAK.has(e.getPlayer())
         ) {
             return;
         }

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemConsumeListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemConsumeListener.java
@@ -1,6 +1,7 @@
 package net.okocraft.box.plugin.listener.stick;
 
 import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.BoxPermission;
 import net.okocraft.box.plugin.model.User;
 import net.okocraft.box.plugin.model.item.Item;
 import org.bukkit.event.EventHandler;
@@ -19,8 +20,10 @@ public class ItemConsumeListener extends AbstractStickListener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemConsume(@NotNull PlayerItemConsumeEvent e) {
         if (isInDisabledWorld(e.getPlayer())
+                || isCreative(e.getPlayer())
                 || !hasStick(e.getPlayer(), false)
-                || isCreative(e.getPlayer())) {
+                || !e.getPlayer().hasPermission(BoxPermission.BOX_STICK_CONSUME.getNode())
+        ) {
             return;
         }
 

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemConsumeListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ItemConsumeListener.java
@@ -22,7 +22,7 @@ public class ItemConsumeListener extends AbstractStickListener {
         if (isInDisabledWorld(e.getPlayer())
                 || isCreative(e.getPlayer())
                 || !hasStick(e.getPlayer(), false)
-                || !e.getPlayer().hasPermission(BoxPermission.BOX_STICK_CONSUME.getNode())
+                || !BoxPermission.BOX_STICK_CONSUME.has(e.getPlayer())
         ) {
             return;
         }

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ProjectileLaunchListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ProjectileLaunchListener.java
@@ -1,6 +1,7 @@
 package net.okocraft.box.plugin.listener.stick;
 
 import net.okocraft.box.plugin.Box;
+import net.okocraft.box.plugin.BoxPermission;
 import net.okocraft.box.plugin.model.User;
 import net.okocraft.box.plugin.model.item.Item;
 import net.okocraft.box.plugin.util.PaperChecker;
@@ -38,8 +39,10 @@ public class ProjectileLaunchListener extends AbstractStickListener {
         Player player = (Player) e.getEntity().getShooter();
 
         if (isInDisabledWorld(player)
+                || isCreative(player)
                 || !hasStick(player, false)
-                || isCreative(player)) {
+                || !player.hasPermission(BoxPermission.BOX_STICK_THROW.getNode())
+        ) {
             return;
         }
 
@@ -85,8 +88,6 @@ public class ProjectileLaunchListener extends AbstractStickListener {
     }
 
     private void useFromStock(@NotNull Player player, @NotNull Material material) {
-        // TODO: 権限チェック
-
         ItemStack hand = player.getInventory().getItemInMainHand();
 
         if (hand.getType() != material) {
@@ -110,8 +111,6 @@ public class ProjectileLaunchListener extends AbstractStickListener {
     }
 
     private void useFromStock(@NotNull Player player, @NotNull ItemStack item) {
-        // TODO: 権限チェック
-
         Optional<Item> boxItem = plugin.getItemManager().getItem(item);
 
         if (boxItem.isEmpty()) {
@@ -130,8 +129,6 @@ public class ProjectileLaunchListener extends AbstractStickListener {
     }
 
     private void useArrowFromStock(@NotNull Player player, @NotNull ItemStack arrow) {
-        // TODO: 権限チェック
-
         if (player.getInventory().getItemInMainHand().containsEnchantment(Enchantment.ARROW_INFINITE)) {
             return;
         }

--- a/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ProjectileLaunchListener.java
+++ b/plugin/src/main/java/net/okocraft/box/plugin/listener/stick/ProjectileLaunchListener.java
@@ -41,7 +41,7 @@ public class ProjectileLaunchListener extends AbstractStickListener {
         if (isInDisabledWorld(player)
                 || isCreative(player)
                 || !hasStick(player, false)
-                || !player.hasPermission(BoxPermission.BOX_STICK_THROW.getNode())
+                || !BoxPermission.BOX_STICK_THROW.has(player)
         ) {
             return;
         }


### PR DESCRIPTION
Box で使用する権限も列挙クラスにし、 `plugin.yml` にすべて書き込まなくてもいいようにする

※ `box.*` のような子権限を持つ権限は除く