### PR TITLE
Implements stock notification (closes #56)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ jobs:
           mv features/command/target staging/features/command
           mv features/craft/target staging/features/craft
           mv features/gui/target staging/features/gui
+          mv features/notifier/target staging/features/notifier
           mv features/stick/target staging/features/stick
           mv migrator/target staging/migrator
       - uses: actions/upload-artifact@v2.2.4

--- a/api/src/main/java/net/okocraft/box/api/event/player/PlayerStockHolderChangeEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/player/PlayerStockHolderChangeEvent.java
@@ -1,0 +1,33 @@
+package net.okocraft.box.api.event.player;
+
+import net.okocraft.box.api.model.stock.StockHolder;
+import net.okocraft.box.api.player.BoxPlayer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An {@link PlayerEvent} called when the player changed the {@link StockHolder}.
+ */
+public class PlayerStockHolderChangeEvent extends PlayerEvent {
+
+    private final StockHolder previous;
+
+    /**
+     * The constructor of a {@link PlayerStockHolderChangeEvent}.
+     *
+     * @param boxPlayer the player of this event
+     */
+    public PlayerStockHolderChangeEvent(@NotNull BoxPlayer boxPlayer,
+                                        @NotNull StockHolder previous) {
+        super(boxPlayer);
+        this.previous = previous;
+    }
+
+    /**
+     * Gets the previous {@link StockHolder} of the player.
+     *
+     * @return the previous {@link StockHolder} of the player
+     */
+    public @NotNull StockHolder getPreviousStockHolder() {
+        return previous;
+    }
+}

--- a/api/src/main/java/net/okocraft/box/api/event/player/PlayerStockHolderChangeEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/player/PlayerStockHolderChangeEvent.java
@@ -15,6 +15,7 @@ public class PlayerStockHolderChangeEvent extends PlayerEvent {
      * The constructor of a {@link PlayerStockHolderChangeEvent}.
      *
      * @param boxPlayer the player of this event
+     * @param previous the previous {@link StockHolder}
      */
     public PlayerStockHolderChangeEvent(@NotNull BoxPlayer boxPlayer,
                                         @NotNull StockHolder previous) {

--- a/api/src/main/java/net/okocraft/box/api/event/stock/StockSetEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/stock/StockSetEvent.java
@@ -11,18 +11,21 @@ public class StockSetEvent extends StockEvent {
 
     private final BoxItem item;
     private final int amount;
+    private final int previousAmount;
 
     /**
      * The constructor of {@link StockEvent}.
      *
-     * @param stockHolder the stockholder of the event
-     * @param item        the item of the stock
-     * @param amount      the current amount of the stock
+     * @param stockHolder    the stockholder of the event
+     * @param item           the item of the stock
+     * @param amount         the current amount of the stock
+     * @param previousAmount the amount of stock before set
      */
-    public StockSetEvent(@NotNull StockHolder stockHolder, @NotNull BoxItem item, int amount) {
+    public StockSetEvent(@NotNull StockHolder stockHolder, @NotNull BoxItem item, int amount, int previousAmount) {
         super(stockHolder);
         this.item = item;
         this.amount = amount;
+        this.previousAmount = previousAmount;
     }
 
     /**
@@ -41,6 +44,15 @@ public class StockSetEvent extends StockEvent {
      */
     public int getAmount() {
         return amount;
+    }
+
+    /**
+     * Gets the amount of stock before set.
+     *
+     * @return the amount of stock before set
+     */
+    public int getPreviousAmount() {
+        return previousAmount;
     }
 
     @Override

--- a/api/src/main/java/net/okocraft/box/api/model/stock/StockHolder.java
+++ b/api/src/main/java/net/okocraft/box/api/model/stock/StockHolder.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * An interface that holds stocks.
@@ -19,6 +20,13 @@ public interface StockHolder {
      * @return the name of this holder
      */
     @NotNull String getName();
+
+    /**
+     * Gets the uuid of this holder.
+     *
+     * @return the uuid of this holder
+     */
+    @NotNull UUID getUUID();
 
     /**
      * Gets the stock quantity of the specified item.

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
         <dependency>
             <groupId>net.okocraft.box.feature</groupId>
+            <artifactId>notifier</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.okocraft.box.feature</groupId>
             <artifactId>stick</artifactId>
             <version>4.0.0-SNAPSHOT</version>
             <scope>compile</scope>

--- a/bundle/src/main/java/net/okocraft/box/bundle/Bundled.java
+++ b/bundle/src/main/java/net/okocraft/box/bundle/Bundled.java
@@ -7,6 +7,7 @@ import net.okocraft.box.feature.command.CommandFeature;
 import net.okocraft.box.feature.craft.CraftFeature;
 import net.okocraft.box.feature.gui.GuiFeature;
 import net.okocraft.box.feature.stick.StickFeature;
+import net.okocraft.feature.notifier.NotifierFeature;
 
 import java.util.List;
 
@@ -14,6 +15,7 @@ final class Bundled {
 
     static final List<BoxFeature> FEATURES =
             List.of(new CategoryFeature(), new CommandFeature(), new GuiFeature(),
-                    new AutoStoreFeature(), new CraftFeature(), new StickFeature());
+                    new AutoStoreFeature(), new CraftFeature(), new StickFeature(),
+                    new NotifierFeature());
 
 }

--- a/core/src/main/java/net/okocraft/box/core/model/stock/AbstractStockHolder.java
+++ b/core/src/main/java/net/okocraft/box/core/model/stock/AbstractStockHolder.java
@@ -38,9 +38,12 @@ public abstract class AbstractStockHolder implements StockHolder {
 
     @Override
     public void setAmount(@NotNull BoxItem item, int amount) {
-        getStock(item).set(amount);
+        var stock = getStock(item);
 
-        BoxProvider.get().getEventBus().callEvent(new StockSetEvent(this, item, amount));
+        var previous = stock.get();
+        stock.set(amount);
+
+        BoxProvider.get().getEventBus().callEvent(new StockSetEvent(this, item, amount, previous));
     }
 
     @Override

--- a/core/src/main/java/net/okocraft/box/core/model/stock/UserStockHolderImpl.java
+++ b/core/src/main/java/net/okocraft/box/core/model/stock/UserStockHolderImpl.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.UUID;
 
 public class UserStockHolderImpl extends AbstractStockHolder implements UserStockHolder {
 
@@ -25,6 +26,11 @@ public class UserStockHolderImpl extends AbstractStockHolder implements UserStoc
     @Override
     public @NotNull String getName() {
         return user.getName().orElse("Unknown");
+    }
+
+    @Override
+    public @NotNull UUID getUUID() {
+        return user.getUUID();
     }
 
     @Override

--- a/core/src/main/java/net/okocraft/box/core/player/BoxPlayerImpl.java
+++ b/core/src/main/java/net/okocraft/box/core/player/BoxPlayerImpl.java
@@ -1,5 +1,7 @@
 package net.okocraft.box.core.player;
 
+import net.okocraft.box.api.BoxProvider;
+import net.okocraft.box.api.event.player.PlayerStockHolderChangeEvent;
 import net.okocraft.box.api.model.stock.StockHolder;
 import net.okocraft.box.api.model.stock.UserStockHolder;
 import net.okocraft.box.api.player.BoxPlayer;
@@ -40,7 +42,9 @@ public class BoxPlayerImpl implements BoxPlayer {
 
     @Override
     public void setCurrentStockHolder(@NotNull StockHolder stockHolder) {
+        var previous = currentHolder;
         currentHolder = Objects.requireNonNull(stockHolder);
+        BoxProvider.get().getEventBus().callEvent(new PlayerStockHolderChangeEvent(this, previous));
     }
 
     @Override

--- a/features/autostore/src/main/java/net/okocraft/box/feature/autostore/listener/ItemListener.java
+++ b/features/autostore/src/main/java/net/okocraft/box/feature/autostore/listener/ItemListener.java
@@ -14,12 +14,6 @@ import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.Component.translatable;
-import static net.kyori.adventure.text.format.NamedTextColor.AQUA;
-import static net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY;
-import static net.kyori.adventure.text.format.NamedTextColor.WHITE;
-
 public class ItemListener implements Listener {
 
     public void register() {
@@ -69,21 +63,11 @@ public class ItemListener implements Listener {
         var setting = AutoStoreFeature.container().get(player);
 
         if (setting.isEnabled() && setting.shouldAutoStore(boxItem.get())) {
-            var current =
-                    BoxProvider.get()
-                            .getBoxPlayerMap()
-                            .get(player)
-                            .getCurrentStockHolder()
-                            .increase(boxItem.get(), item.getAmount());
-
-            player.sendActionBar(
-                    translatable(boxItem.get().getOriginal())
-                            .append(text(" - ", DARK_GRAY))
-                            .append(text(current, WHITE))
-                            .append(text(" (", DARK_GRAY))
-                            .append(text("+" + item.getAmount(), AQUA))
-                            .append(text(")", DARK_GRAY))
-            );
+            BoxProvider.get()
+                    .getBoxPlayerMap()
+                    .get(player)
+                    .getCurrentStockHolder()
+                    .increase(boxItem.get(), item.getAmount());
 
             player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.2f, (float) Math.random() + 1.0f);
             return true;

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/InfinityCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/InfinityCommand.java
@@ -18,10 +18,9 @@ import org.jetbrains.annotations.Unmodifiable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 public class InfinityCommand extends AbstractCommand {
-
-    private static final StockHolder INFINITY_STOCK_HOLDER = new InfinityStockHolder();
 
     public InfinityCommand() {
         super("infinity", "box.admin.command.infinity", Set.of("i", "inf"));
@@ -52,11 +51,11 @@ public class InfinityCommand extends AbstractCommand {
 
         boolean enabled;
 
-        if (boxPlayer.getCurrentStockHolder() == INFINITY_STOCK_HOLDER) {
+        if (boxPlayer.getCurrentStockHolder() instanceof InfinityStockHolder) {
             boxPlayer.setCurrentStockHolder(boxPlayer.getUserStockHolder());
             enabled = false;
         } else {
-            boxPlayer.setCurrentStockHolder(INFINITY_STOCK_HOLDER);
+            boxPlayer.setCurrentStockHolder(new InfinityStockHolder());
             enabled = true;
         }
 
@@ -81,9 +80,16 @@ public class InfinityCommand extends AbstractCommand {
 
     private static class InfinityStockHolder implements StockHolder {
 
+        private final UUID uuid = UUID.randomUUID();
+
         @Override
         public @NotNull String getName() {
             return "infinity";
+        }
+
+        @Override
+        public @NotNull UUID getUUID() {
+            return uuid;
         }
 
         @Override

--- a/features/notifier/pom.xml
+++ b/features/notifier/pom.xml
@@ -6,20 +6,21 @@
 
     <parent>
         <groupId>net.okocraft.box</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>features</artifactId>
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>features</artifactId>
-    <packaging>pom</packaging>
+    <groupId>net.okocraft.box.feature</groupId>
+    <artifactId>notifier</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
 
-    <modules>
-        <module>autostore</module>
-        <module>command</module>
-        <module>stick</module>
-        <module>category</module>
-        <module>gui</module>
-        <module>craft</module>
-        <module>notifier</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>net.okocraft.box</groupId>
+            <artifactId>api</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/features/notifier/src/main/java/net/okocraft/feature/notifier/NotifierFeature.java
+++ b/features/notifier/src/main/java/net/okocraft/feature/notifier/NotifierFeature.java
@@ -1,0 +1,23 @@
+package net.okocraft.feature.notifier;
+
+import net.okocraft.box.api.feature.AbstractBoxFeature;
+import net.okocraft.feature.notifier.listener.StockHolderListener;
+
+public class NotifierFeature extends AbstractBoxFeature {
+
+    private final StockHolderListener stockHolderListener = new StockHolderListener();
+
+    public NotifierFeature() {
+        super("notifier");
+    }
+
+    @Override
+    public void enable() {
+        stockHolderListener.register(getListenerKey());
+    }
+
+    @Override
+    public void disable() {
+        stockHolderListener.unregister();
+    }
+}

--- a/features/notifier/src/main/java/net/okocraft/feature/notifier/factory/NotificationFactory.java
+++ b/features/notifier/src/main/java/net/okocraft/feature/notifier/factory/NotificationFactory.java
@@ -1,0 +1,74 @@
+package net.okocraft.feature.notifier.factory;
+
+import net.kyori.adventure.text.Component;
+import net.okocraft.box.api.model.item.BoxItem;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.NamedTextColor.AQUA;
+import static net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.NamedTextColor.WHITE;
+
+public class NotificationFactory {
+
+    private static final Component COMMON_PARTS_1 = text(" - ", DARK_GRAY);
+    private static final Component COMMON_PARTS_2 = text(" (", DARK_GRAY);
+    private static final Component COMMON_PARTS_3 = text(")", DARK_GRAY);
+
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull NotificationFactory create(@NotNull BoxItem item) {
+        return new NotificationFactory(item);
+    }
+
+    private final BoxItem item;
+    private int current;
+    private int diff;
+
+    private NotificationFactory(@NotNull BoxItem item) {
+        this.item = item;
+    }
+
+    @Contract("_ -> this")
+    public @NotNull NotificationFactory current(int current) {
+        this.current = current;
+        return this;
+    }
+
+    @Contract("_ -> this")
+    public @NotNull NotificationFactory increments(int increments) {
+        this.diff += increments;
+        return this;
+    }
+
+    @Contract("_ -> this")
+    public @NotNull NotificationFactory decrements(int decrements) {
+        this.diff -= decrements;
+        return this;
+    }
+
+    @Contract("_ -> this")
+    public @NotNull NotificationFactory previous(int previous) {
+        this.diff += current - previous;
+        return this;
+    }
+
+    public @NotNull Component build() {
+        var notification =
+                translatable()
+                        .key(item.getOriginal())
+                        .append(COMMON_PARTS_1)
+                        .append(text(current, WHITE));
+
+        if (diff != 0) {
+            var minus = diff < 0;
+            notification.append(COMMON_PARTS_2)
+                    .append(text((minus ? "-" : "+") + Math.abs(diff), minus ? RED : AQUA))
+                    .append(COMMON_PARTS_3);
+        }
+
+        return notification.build();
+    }
+}

--- a/features/notifier/src/main/java/net/okocraft/feature/notifier/listener/StockHolderListener.java
+++ b/features/notifier/src/main/java/net/okocraft/feature/notifier/listener/StockHolderListener.java
@@ -1,0 +1,129 @@
+package net.okocraft.feature.notifier.listener;
+
+import com.github.siroshun09.event4j.handlerlist.Key;
+import net.kyori.adventure.text.Component;
+import net.okocraft.box.api.BoxProvider;
+import net.okocraft.box.api.event.player.PlayerStockHolderChangeEvent;
+import net.okocraft.box.api.event.stock.StockDecreaseEvent;
+import net.okocraft.box.api.event.stock.StockEvent;
+import net.okocraft.box.api.event.stock.StockIncreaseEvent;
+import net.okocraft.box.api.event.stock.StockSetEvent;
+import net.okocraft.box.api.model.stock.StockHolder;
+import net.okocraft.box.api.model.stock.UserStockHolder;
+import net.okocraft.feature.notifier.factory.NotificationFactory;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class StockHolderListener {
+
+    // stockholder uuid - player uuids
+    private final Map<UUID, List<UUID>> stockHolderMap = new HashMap<>();
+
+    private Key listenerKey;
+
+    public void register(@NotNull Key listenerKey) {
+        this.listenerKey = listenerKey;
+
+        var eventBus = BoxProvider.get().getEventBus();
+
+        eventBus.getHandlerList(StockIncreaseEvent.class).subscribe(listenerKey, this::onIncrease);
+        eventBus.getHandlerList(StockDecreaseEvent.class).subscribe(listenerKey, this::onDecrease);
+        eventBus.getHandlerList(StockSetEvent.class).subscribe(listenerKey, this::onSet);
+
+        eventBus.getHandlerList(PlayerStockHolderChangeEvent.class).subscribe(listenerKey, this::onStockHolderChange);
+    }
+
+    public void unregister() {
+        if (listenerKey == null) {
+            return;
+        }
+
+        var eventBus = BoxProvider.get().getEventBus();
+
+        eventBus.getHandlerList(StockIncreaseEvent.class).unsubscribeAll(listenerKey);
+        eventBus.getHandlerList(StockDecreaseEvent.class).unsubscribeAll(listenerKey);
+        eventBus.getHandlerList(StockSetEvent.class).unsubscribeAll(listenerKey);
+
+        eventBus.getHandlerList(PlayerStockHolderChangeEvent.class).unsubscribeAll(listenerKey);
+    }
+
+    public void onIncrease(@NotNull StockIncreaseEvent event) {
+        var notification =
+                NotificationFactory.create(event.getItem())
+                        .current(event.getAmount())
+                        .increments(event.getIncrements())
+                        .build();
+
+        notify(event, notification);
+    }
+
+    public void onDecrease(@NotNull StockDecreaseEvent event) {
+        var notification =
+                NotificationFactory.create(event.getItem())
+                        .current(event.getAmount())
+                        .decrements(event.getDecrements())
+                        .build();
+
+        notify(event, notification);
+    }
+
+    public void onSet(@NotNull StockSetEvent event) {
+        var notification =
+                NotificationFactory.create(event.getItem())
+                        .current(event.getAmount())
+                        .previous(event.getPreviousAmount())
+                        .build();
+
+        notify(event, notification);
+    }
+
+    private void notify(@NotNull StockEvent event, @NotNull Component notification) {
+        if (event.isUserStockHolder()) {
+            Optional.of(event.getStockHolder())
+                    .map(StockHolder::getUUID)
+                    .map(Bukkit::getPlayer)
+                    .ifPresent(player -> player.sendActionBar(notification));
+        } else {
+            stockHolderMap.get(event.getStockHolder().getUUID())
+                    .stream()
+                    .map(Bukkit::getPlayer)
+                    .filter(Objects::nonNull)
+                    .forEach(player -> player.sendActionBar(notification));
+        }
+    }
+
+    public void onStockHolderChange(@NotNull PlayerStockHolderChangeEvent event) {
+        var playerUuid = event.getBoxPlayer().getUUID();
+
+        var previousStockHolder = event.getPreviousStockHolder();
+        var currentStockHolder = event.getBoxPlayer().getCurrentStockHolder();
+
+        if (!(currentStockHolder instanceof UserStockHolder)) {
+            addToMap(currentStockHolder.getUUID(), playerUuid);
+        }
+
+        if (!(previousStockHolder instanceof UserStockHolder)) {
+            removeFromMap(previousStockHolder.getUUID(), playerUuid);
+        }
+    }
+
+    private void addToMap(@NotNull UUID stockHolderUuid, @NotNull UUID playerUuid) {
+        stockHolderMap.computeIfAbsent(stockHolderUuid, k -> new ArrayList<>()).add(playerUuid);
+    }
+
+    private void removeFromMap(@NotNull UUID stockHolderUuid, @NotNull UUID playerUuid) {
+        var list = stockHolderMap.get(stockHolderUuid);
+
+        if (list != null) {
+            list.remove(playerUuid);
+        }
+    }
+}

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/listener/StickListener.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/listener/StickListener.java
@@ -24,11 +24,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.jetbrains.annotations.NotNull;
 
-import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.Component.translatable;
-import static net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY;
-import static net.kyori.adventure.text.format.NamedTextColor.WHITE;
-
 @SuppressWarnings("ClassCanBeRecord")
 public class StickListener implements Listener {
 
@@ -184,12 +179,7 @@ public class StickListener implements Listener {
         var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
 
         if (0 < stockHolder.getAmount(boxItem.get())) {
-            int current = stockHolder.decrease(boxItem.get());
-            player.sendActionBar(
-                    translatable(boxItem.get().getOriginal())
-                            .append(text(" - ", DARK_GRAY))
-                            .append(text(current, WHITE))
-            );
+            stockHolder.decrease(boxItem.get());
             return true;
         } else {
             return false;


### PR DESCRIPTION
autostore と stick にあるアクションバーへのストック通知機能を統合する。

`StockEvent` 関連を使っているため、例えば GUI での操作も通知される。

### API Addition
- `StockHolder#getUUID`
- `StockSetEvent#getPreviousAmount`
- `PlayerStockHolderChangeEvent`