### PR TITLE
Add TaskFactory

### DIFF
--- a/api/src/main/java/net/okocraft/box/api/BoxAPI.java
+++ b/api/src/main/java/net/okocraft/box/api/BoxAPI.java
@@ -16,6 +16,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -119,6 +120,8 @@ public interface BoxAPI {
      *
      * @return the {@link ExecutorProvider}
      */
+    @Deprecated(forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = "4.2.0")
     @NotNull ExecutorProvider getExecutorProvider();
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/BoxAPI.java
+++ b/api/src/main/java/net/okocraft/box/api/BoxAPI.java
@@ -10,6 +10,7 @@ import net.okocraft.box.api.model.manager.ItemManager;
 import net.okocraft.box.api.model.manager.StockManager;
 import net.okocraft.box.api.model.manager.UserManager;
 import net.okocraft.box.api.player.BoxPlayerMap;
+import net.okocraft.box.api.taskfactory.TaskFactory;
 import net.okocraft.box.api.util.ExecutorProvider;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
@@ -105,6 +106,13 @@ public interface BoxAPI {
      * @return the {@link CustomDataContainer}
      */
     @NotNull CustomDataContainer getCustomDataContainer();
+
+    /**
+     * Gets the {@link TaskFactory}.
+     *
+     * @return the {@link TaskFactory}
+     */
+    @NotNull TaskFactory getTaskFactory();
 
     /**
      * Gets the {@link ExecutorProvider}.

--- a/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
+++ b/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
@@ -1,0 +1,47 @@
+package net.okocraft.box.api.taskfactory;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * An interface to create {@link CompletableFuture}s.
+ */
+public interface TaskFactory {
+
+    /**
+     * Creates a {@link CompletableFuture} to run the task on main thread.
+     *
+     * @param task the task to run
+     * @return the new {@link CompletableFuture}
+     */
+    @NotNull CompletableFuture<Void> run(@NotNull Runnable task);
+
+    /**
+     * Creates a {@link CompletableFuture} to supply values on main thread.
+     *
+     * @param supplier the supplier
+     * @param <T>      the value type
+     * @return the new {@link CompletableFuture}
+     */
+    <T> @NotNull CompletableFuture<T> supply(@NotNull Supplier<T> supplier);
+
+    /**
+     * Creates a {@link CompletableFuture} to run the task asynchronously.
+     *
+     * @param task the task to run
+     * @return the new {@link CompletableFuture}
+     */
+    @NotNull CompletableFuture<Void> runAsync(@NotNull Runnable task);
+
+    /**
+     * Creates a {@link CompletableFuture} to supply values asynchronously.
+     *
+     * @param supplier the supplier
+     * @param <T>      the value type
+     * @return the new {@link CompletableFuture}
+     */
+    <T> @NotNull CompletableFuture<T> supplyAsync(@NotNull Supplier<T> supplier);
+
+}

--- a/api/src/main/java/net/okocraft/box/api/util/ExecutorProvider.java
+++ b/api/src/main/java/net/okocraft/box/api/util/ExecutorProvider.java
@@ -1,5 +1,6 @@
 package net.okocraft.box.api.util;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.Executor;
@@ -7,6 +8,8 @@ import java.util.concurrent.Executor;
 /**
  * An interface for providing {@link Executor}s.
  */
+@Deprecated(forRemoval = true)
+@ApiStatus.ScheduledForRemoval(inVersion = "4.2.0")
 public interface ExecutorProvider {
 
     /**

--- a/core/src/main/java/net/okocraft/box/core/BoxPlugin.java
+++ b/core/src/main/java/net/okocraft/box/core/BoxPlugin.java
@@ -18,6 +18,7 @@ import net.okocraft.box.api.model.manager.ItemManager;
 import net.okocraft.box.api.model.manager.StockManager;
 import net.okocraft.box.api.model.manager.UserManager;
 import net.okocraft.box.api.player.BoxPlayerMap;
+import net.okocraft.box.api.taskfactory.TaskFactory;
 import net.okocraft.box.api.util.ExecutorProvider;
 import net.okocraft.box.core.command.BoxAdminCommandImpl;
 import net.okocraft.box.core.command.BoxCommandImpl;
@@ -35,6 +36,7 @@ import net.okocraft.box.core.player.BoxPlayerMapImpl;
 import net.okocraft.box.core.storage.Storage;
 import net.okocraft.box.core.storage.implementations.yaml.YamlStorage;
 import net.okocraft.box.core.task.AutoSaveTask;
+import net.okocraft.box.core.taskfactory.BoxTaskFactory;
 import net.okocraft.box.core.util.executor.BoxExecutorProvider;
 import net.okocraft.box.core.util.executor.InternalExecutors;
 import org.bukkit.Bukkit;
@@ -70,6 +72,7 @@ public class BoxPlugin implements BoxAPI {
     private final DebugListener debugListener = new DebugListener();
 
     private final EventBus eventBus = EventBus.newEventBus();
+    private final BoxTaskFactory taskFactory = new BoxTaskFactory();
     private final BoxExecutorProvider executorProvider = new BoxExecutorProvider();
 
     private final BoxCommandImpl boxCommand = new BoxCommandImpl();
@@ -337,6 +340,11 @@ public class BoxPlugin implements BoxAPI {
     @Override
     public @NotNull CustomDataContainer getCustomDataContainer() {
         return customDataContainer;
+    }
+
+    @Override
+    public @NotNull TaskFactory getTaskFactory() {
+        return taskFactory;
     }
 
     @Override

--- a/core/src/main/java/net/okocraft/box/core/BoxPlugin.java
+++ b/core/src/main/java/net/okocraft/box/core/BoxPlugin.java
@@ -224,7 +224,7 @@ public class BoxPlugin implements BoxAPI {
         getLogger().info("Shutting down executors...");
 
         try {
-            executorProvider.shutdown();
+            taskFactory.shutdown();
             InternalExecutors.shutdownAll();
         } catch (InterruptedException e) {
             getLogger().log(Level.SEVERE, "Could not shutdown executors", e);

--- a/core/src/main/java/net/okocraft/box/core/command/BaseCommand.java
+++ b/core/src/main/java/net/okocraft/box/core/command/BaseCommand.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import static net.kyori.adventure.text.Component.text;
@@ -171,10 +170,9 @@ public abstract class BaseCommand implements Command, SubCommandHoldable, Comman
     }
 
     private void runCommandAsync(@NotNull Command command, @NotNull CommandSender sender, @NotNull String[] args) {
-        CompletableFuture.runAsync(
-                () -> command.onCommand(sender, args),
-                BoxProvider.get().getExecutorProvider().getExecutor()
-        ).exceptionallyAsync(e -> reportError(sender, args, e));
+        BoxProvider.get().getTaskFactory()
+                .runAsync(() -> command.onCommand(sender, args))
+                .exceptionallyAsync(e -> reportError(sender, args, e));
     }
 
     private @Nullable Void reportError(@NotNull CommandSender sender, @NotNull String[] args, @NotNull Throwable throwable) {

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -1,0 +1,66 @@
+package net.okocraft.box.core.taskfactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import net.okocraft.box.api.BoxProvider;
+import net.okocraft.box.api.taskfactory.TaskFactory;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+public class BoxTaskFactory implements TaskFactory {
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(
+            Math.min(Runtime.getRuntime().availableProcessors(), 4),
+            new ThreadFactoryBuilder()
+                    .setDaemon(true)
+                    .setNameFormat("box-worker-%d")
+                    .setUncaughtExceptionHandler(this::reportUncaughtException)
+                    .build()
+    );
+
+    @Override
+    public @NotNull CompletableFuture<Void> run(@NotNull Runnable task) {
+        return CompletableFuture.runAsync(task, getMainThread());
+    }
+
+    @Override
+    public @NotNull <T> CompletableFuture<T> supply(@NotNull Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(supplier, getMainThread());
+    }
+
+    @Override
+    public @NotNull CompletableFuture<Void> runAsync(@NotNull Runnable task) {
+        return CompletableFuture.runAsync(task, executor);
+    }
+
+    @Override
+    public @NotNull <T> CompletableFuture<T> supplyAsync(@NotNull Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(supplier, executor);
+    }
+
+    public void shutdown() throws InterruptedException {
+        executor.shutdown();
+
+        //noinspection ResultOfMethodCallIgnored
+        executor.awaitTermination(1, TimeUnit.MINUTES);
+    }
+
+    private void reportUncaughtException(@NotNull Thread thread, @NotNull Throwable throwable) {
+        BoxProvider.get().getLogger().log(
+                Level.SEVERE,
+                "An exception occurred in the thread " + thread.getName(),
+                throwable
+        );
+    }
+
+    private @NotNull Executor getMainThread() {
+        return Bukkit.getScheduler().getMainThreadExecutor(BoxProvider.get().getPluginInstance());
+    }
+}

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -60,7 +60,11 @@ public class BoxTaskFactory implements TaskFactory {
         );
     }
 
-    private @NotNull Executor getMainThread() {
+    public @NotNull Executor getExecutor() {
+        return executor;
+    }
+
+    public @NotNull Executor getMainThread() {
         return Bukkit.getScheduler().getMainThreadExecutor(BoxProvider.get().getPluginInstance());
     }
 }

--- a/core/src/main/java/net/okocraft/box/core/util/executor/BoxExecutorProvider.java
+++ b/core/src/main/java/net/okocraft/box/core/util/executor/BoxExecutorProvider.java
@@ -1,51 +1,21 @@
 package net.okocraft.box.core.util.executor;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.util.ExecutorProvider;
-import org.bukkit.Bukkit;
+import net.okocraft.box.core.taskfactory.BoxTaskFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 public class BoxExecutorProvider implements ExecutorProvider {
 
-    private final ExecutorService executor = Executors.newFixedThreadPool(
-            Math.min(Runtime.getRuntime().availableProcessors(), 4),
-            new ThreadFactoryBuilder()
-                    .setDaemon(true)
-                    .setNameFormat("box-worker-%d")
-                    .setUncaughtExceptionHandler(this::reportUncaughtException)
-                    .build()
-    );
-
     @Override
     public @NotNull Executor getExecutor() {
-        return executor;
+        return ((BoxTaskFactory) BoxProvider.get().getTaskFactory()).getExecutor();
     }
 
     @Override
     public @NotNull Executor getMainThread() {
-        return Bukkit.getScheduler().getMainThreadExecutor(BoxProvider.get().getPluginInstance());
-    }
-
-    public void shutdown() throws InterruptedException {
-        executor.shutdown();
-
-        //noinspection ResultOfMethodCallIgnored
-        executor.awaitTermination(1, TimeUnit.MINUTES);
-    }
-
-
-    private void reportUncaughtException(@NotNull Thread thread, @NotNull Throwable throwable) {
-        BoxProvider.get().getLogger().log(
-                Level.SEVERE,
-                "An exception occurred in the thread " + thread.getName(),
-                throwable
-        );
+        return ((BoxTaskFactory) BoxProvider.get().getTaskFactory()).getMainThread();
     }
 }

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/DepositCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/DepositCommand.java
@@ -21,7 +21,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -97,10 +96,9 @@ public class DepositCommand extends AbstractCommand {
 
     private void depositItemInMainHand(@NotNull Player player, int amount) {
         var result =
-                CompletableFuture.supplyAsync(
-                        () -> InventoryTransaction.depositItemInMainHand(player, amount),
-                        BoxProvider.get().getExecutorProvider().getMainThread()
-                ).join();
+                BoxProvider.get().getTaskFactory()
+                        .supply(() -> InventoryTransaction.depositItemInMainHand(player, amount))
+                        .join();
 
         if (result.getType().isModified()) {
             var item = result.getItem();
@@ -122,10 +120,9 @@ public class DepositCommand extends AbstractCommand {
 
     private void depositAll(@NotNull Player player) {
         var resultList =
-                CompletableFuture.supplyAsync(
-                        () -> InventoryTransaction.depositItemsInInventory(player.getInventory()),
-                        BoxProvider.get().getExecutorProvider().getMainThread()
-                ).join();
+                BoxProvider.get().getTaskFactory()
+                        .supply(() -> InventoryTransaction.depositItemsInInventory(player.getInventory()))
+                        .join();
 
         var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
 
@@ -138,10 +135,9 @@ public class DepositCommand extends AbstractCommand {
 
     private void depositItem(@NotNull Player player, @NotNull BoxItem boxItem, int amount) {
         var resultList =
-                CompletableFuture.supplyAsync(
-                        () -> InventoryTransaction.depositItem(player.getInventory(), boxItem, amount),
-                        BoxProvider.get().getExecutorProvider().getMainThread()
-                ).join();
+                BoxProvider.get().getTaskFactory()
+                        .supply(() -> InventoryTransaction.depositItem(player.getInventory(), boxItem, amount))
+                        .join();
 
         var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
 

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/WithdrawCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/WithdrawCommand.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class WithdrawCommand extends AbstractCommand {
@@ -70,10 +69,9 @@ public class WithdrawCommand extends AbstractCommand {
         }
 
         var result =
-                CompletableFuture.supplyAsync(
-                        () -> InventoryTransaction.withdraw(player.getInventory(), boxItem, amount),
-                        BoxProvider.get().getExecutorProvider().getMainThread()
-                ).join();
+                BoxProvider.get().getTaskFactory()
+                        .supply(() -> InventoryTransaction.withdraw(player.getInventory(), boxItem, amount))
+                        .join();
 
         var resultType = result.getType();
 

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/util/ItemCrafter.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/util/ItemCrafter.java
@@ -9,7 +9,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
-import java.util.concurrent.CompletableFuture;
 
 public class ItemCrafter {
 
@@ -52,13 +51,15 @@ public class ItemCrafter {
         int storeAmount = resultAmount;
 
         if (Distribution.toInventory(crafter)) {
-            var result = CompletableFuture.supplyAsync(
-                    () -> InventoryTransaction.withdraw(
-                            crafter.getInventory(),
-                            recipe.result(),
-                            resultAmount
-                    ), BoxProvider.get().getExecutorProvider().getMainThread()
-            ).join();
+            var result =
+                    BoxProvider.get().getTaskFactory()
+                            .supply(() ->
+                                    InventoryTransaction.withdraw(
+                                            crafter.getInventory(),
+                                            recipe.result(),
+                                            resultAmount
+                                    )
+                            ).join();
 
             if (result.getType().isModified()) {
                 storeAmount = resultAmount - result.getAmount();

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/util/ItemCrafter.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/util/ItemCrafter.java
@@ -52,14 +52,9 @@ public class ItemCrafter {
 
         if (Distribution.toInventory(crafter)) {
             var result =
-                    BoxProvider.get().getTaskFactory()
-                            .supply(() ->
-                                    InventoryTransaction.withdraw(
-                                            crafter.getInventory(),
-                                            recipe.result(),
-                                            resultAmount
-                                    )
-                            ).join();
+                    BoxProvider.get().getTaskFactory().supply(
+                            () -> InventoryTransaction.withdraw(crafter.getInventory(), recipe.result(), resultAmount)
+                    ).join();
 
             if (result.getType().isModified()) {
                 storeAmount = resultAmount - result.getAmount();

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/GuiFeature.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/GuiFeature.java
@@ -16,8 +16,6 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.CompletableFuture;
-
 public class GuiFeature extends AbstractBoxFeature implements Reloadable {
 
     private final MenuOpenCommand command = new MenuOpenCommand();
@@ -53,10 +51,7 @@ public class GuiFeature extends AbstractBoxFeature implements Reloadable {
         if (Bukkit.isPrimaryThread()) {
             closeMenus();
         } else {
-            CompletableFuture.runAsync(
-                    this::closeMenus,
-                    BoxProvider.get().getExecutorProvider().getMainThread()
-            ).join();
+            BoxProvider.get().getTaskFactory().run(this::closeMenus).join();
         }
 
         HandlerList.unregisterAll(listener);

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/api/buttons/CloseButton.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/api/buttons/CloseButton.java
@@ -13,8 +13,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.concurrent.CompletableFuture;
-
 public class CloseButton implements Button {
 
     @Override
@@ -40,10 +38,7 @@ public class CloseButton implements Button {
 
     @Override
     public void onClick(@NotNull Player clicker, @NotNull ClickType clickType) {
-        CompletableFuture.runAsync(
-                clicker::closeInventory, BoxProvider.get().getExecutorProvider().getMainThread()
-        );
-
+        BoxProvider.get().getTaskFactory().run(clicker::closeInventory);
         clicker.playSound(clicker.getLocation(), Sound.BLOCK_CHEST_CLOSE, SoundCategory.MASTER, 100f, 1.5f);
     }
 }

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/api/util/MenuOpener.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/api/util/MenuOpener.java
@@ -7,8 +7,6 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.CompletableFuture;
-
 public final class MenuOpener {
 
     public static void open(@NotNull Menu menu, @NotNull Player viewer) {
@@ -17,10 +15,9 @@ public final class MenuOpener {
         holder.initializeMenu(viewer);
         holder.applyContents();
 
-        CompletableFuture.runAsync(
-                () -> viewer.openInventory(holder.getInventory()),
-                BoxProvider.get().getExecutorProvider().getMainThread()
-        ).join();
+        BoxProvider.get().getTaskFactory()
+                .run(() -> viewer.openInventory(holder.getInventory()))
+                .join();
 
         viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 100f, 2.0f);
     }

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/listener/InventoryListener.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/listener/InventoryListener.java
@@ -58,17 +58,17 @@ public class InventoryListener implements Listener {
 
         this.lastClickTime.put(clicker.getUniqueId(), System.currentTimeMillis());
 
-        var task = CompletableFuture.runAsync(
-                () -> processClick(holder, clicker, event.getSlot(), event.getClick()),
-                BoxProvider.get().getExecutorProvider().getExecutor()
-        ).exceptionallyAsync(throwable -> {
-            BoxProvider.get().getLogger().log(
-                    Level.SEVERE,
-                    "Could not complete click task (" + clicker.getName() + ")",
-                    throwable
-            );
-            return null;
-        });
+        var task =
+                BoxProvider.get().getTaskFactory()
+                        .runAsync(() -> processClick(holder, clicker, event.getSlot(), event.getClick()))
+                        .exceptionallyAsync(throwable -> {
+                            BoxProvider.get().getLogger().log(
+                                    Level.SEVERE,
+                                    "Could not complete click task (" + clicker.getName() + ")",
+                                    throwable
+                            );
+                            return null;
+                        });
 
         clickTaskMap.put(clicker.getUniqueId(), task);
     }
@@ -78,10 +78,7 @@ public class InventoryListener implements Listener {
         holder.processClick(clicker, slot, type);
 
         if (holder.updateMenu(clicker)) {
-            CompletableFuture.runAsync(
-                    () -> holder.updateInventory(clicker),
-                    BoxProvider.get().getExecutorProvider().getMainThread()
-            ).join();
+            BoxProvider.get().getTaskFactory().run(() -> holder.updateInventory(clicker)).join();
         }
     }
 }

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/mode/StorageMode.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/mode/StorageMode.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Unmodifiable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 public class StorageMode implements BoxItemClickMode {
 
@@ -94,14 +93,14 @@ public class StorageMode implements BoxItemClickMode {
         int transactionAmount =
                 PlayerSession.get(player).getCustomNumberHolder(TRANSACTION_AMOUNT_NAME).getAmount();
 
-        var resultList = CompletableFuture.supplyAsync(
-                () -> InventoryTransaction.depositItem(
-                        player.getInventory(),
-                        context.item(),
-                        transactionAmount
-                ),
-                BoxProvider.get().getExecutorProvider().getMainThread()
-        ).join();
+        var resultList =
+                BoxProvider.get().getTaskFactory()
+                        .supply(() -> InventoryTransaction.depositItem(
+                                        player.getInventory(),
+                                        context.item(),
+                                        transactionAmount
+                                )
+                        ).join();
 
         if (!resultList.getType().isModified()) {
             player.playSound(player.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 100f, 1.5f);
@@ -134,10 +133,10 @@ public class StorageMode implements BoxItemClickMode {
 
         var amount = Math.min(currentStock, transactionAmount);
 
-        var result = CompletableFuture.supplyAsync(
-                () -> InventoryTransaction.withdraw(player.getInventory(), context.item(), amount),
-                BoxProvider.get().getExecutorProvider().getMainThread()
-        ).join();
+        var result =
+                BoxProvider.get().getTaskFactory()
+                        .supply(() -> InventoryTransaction.withdraw(player.getInventory(), context.item(), amount))
+                        .join();
 
         if (result.getType().isModified()) {
             stockHolder.decrease(result.getItem(), result.getAmount());
@@ -180,10 +179,10 @@ public class StorageMode implements BoxItemClickMode {
                 return;
             }
 
-            var resultList = CompletableFuture.supplyAsync(
-                    () -> InventoryTransaction.depositItemsInInventory(clicker.getInventory()),
-                    BoxProvider.get().getExecutorProvider().getMainThread()
-            ).join();
+            var resultList =
+                    BoxProvider.get().getTaskFactory()
+                            .supply(() -> InventoryTransaction.depositItemsInInventory(clicker.getInventory()))
+                            .join();
 
             if (!resultList.getType().isModified()) {
                 clicker.playSound(clicker.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 100f, 1.5f);

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/mode/StorageMode.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/mode/StorageMode.java
@@ -94,13 +94,9 @@ public class StorageMode implements BoxItemClickMode {
                 PlayerSession.get(player).getCustomNumberHolder(TRANSACTION_AMOUNT_NAME).getAmount();
 
         var resultList =
-                BoxProvider.get().getTaskFactory()
-                        .supply(() -> InventoryTransaction.depositItem(
-                                        player.getInventory(),
-                                        context.item(),
-                                        transactionAmount
-                                )
-                        ).join();
+                BoxProvider.get().getTaskFactory().supply(
+                        () -> InventoryTransaction.depositItem(player.getInventory(), context.item(), transactionAmount)
+                ).join();
 
         if (!resultList.getType().isModified()) {
             player.playSound(player.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 100f, 1.5f);

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/command/CustomStickCommand.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/command/CustomStickCommand.java
@@ -10,8 +10,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.CompletableFuture;
-
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.NamedTextColor.AQUA;
@@ -58,10 +56,7 @@ public class CustomStickCommand extends AbstractCommand {
             return;
         }
 
-        CompletableFuture.runAsync(
-                () -> makeStick(player),
-                BoxProvider.get().getExecutorProvider().getMainThread()
-        ).join();
+        BoxProvider.get().getTaskFactory().run(() -> makeStick(player)).join();
     }
 
     private void makeStick(@NotNull Player player) {

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/command/StickCommand.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/command/StickCommand.java
@@ -10,7 +10,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
@@ -49,10 +48,7 @@ public class StickCommand extends AbstractCommand {
             return;
         }
 
-        CompletableFuture.runAsync(
-                () -> runCommand(player),
-                BoxProvider.get().getExecutorProvider().getMainThread()
-        ).join();
+        BoxProvider.get().getTaskFactory().run(() -> runCommand(player)).join();
     }
 
     private void runCommand(@NotNull Player player) {


### PR DESCRIPTION
`CompletableFuture.runAsync(Runnable, Executor)` を随所で書くのは手間で見辛くもなるので、`TaskFactory` を API に追加し `CompletableFuture` を楽に作成できるようにする。

## 追加

- `TaskFactory` - `CompletableFuture` を作成するインターフェース
  - `TaskFactory#run` - サーバースレッドで `Runnable` を実行
  - `TaskFactory#supply` - サーバースレッドで `Supplier` を実行
  - `TaskFactory#runAsync` - Box のスレッドプールで `Runnable` を実行 (非同期)
  - `TaskFactory#supplyAsync` - Box のスレッドプールで `Supplier` を実行 (非同期)
- `BoxAPI#getTaskFactory` - `TaskFactory` のインスタンスを取得

## 非推奨・削除予定

`ExecutorProvider` と `BoxAPI#getExecutorProvider` は非推奨とし、`4.2.0` で削除する

## その他変更

`ExecutorProvider` の使用箇所を `TaskFactory` に置き換え