### PR TITLE
Add more null checks for api

### DIFF
--- a/api/src/main/java/net/okocraft/box/api/BoxProvider.java
+++ b/api/src/main/java/net/okocraft/box/api/BoxProvider.java
@@ -2,6 +2,8 @@ package net.okocraft.box.api;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A class to provide {@link BoxAPI}.
  */
@@ -31,7 +33,7 @@ public final class BoxProvider {
      */
     public static void set(@NotNull BoxAPI api) {
         if (API == null) {
-            API = api;
+            API = Objects.requireNonNull(api);
         } else {
             throw new IllegalStateException("BoxAPI is already set.");
         }

--- a/api/src/main/java/net/okocraft/box/api/command/AbstractCommand.java
+++ b/api/src/main/java/net/okocraft/box/api/command/AbstractCommand.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -40,9 +41,9 @@ public abstract class AbstractCommand implements Command {
      * @param aliases        the set of aliases
      */
     public AbstractCommand(@NotNull String name, @NotNull String permissionNode, @NotNull Set<String> aliases) {
-        this.name = name;
-        this.permissionNode = permissionNode;
-        this.aliases = aliases;
+        this.name = Objects.requireNonNull(name);
+        this.permissionNode = Objects.requireNonNull(permissionNode);
+        this.aliases = Objects.requireNonNull(aliases);
     }
 
     public @NotNull String getName() {

--- a/api/src/main/java/net/okocraft/box/api/command/SubCommandHoldable.java
+++ b/api/src/main/java/net/okocraft/box/api/command/SubCommandHoldable.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -34,6 +35,7 @@ public interface SubCommandHoldable {
          * @param subCommands the set of subcommands
          */
         public SubCommandHolder(@NotNull Command... subCommands) {
+            Objects.requireNonNull(subCommands);
             this.subCommands = new ArrayList<>(Arrays.asList(subCommands));
         }
 
@@ -74,7 +76,7 @@ public interface SubCommandHoldable {
          * @return the search result
          */
         public @NotNull Optional<Command> search(@NotNull String name) {
-            name = name.toLowerCase(Locale.ROOT);
+            name = Objects.requireNonNull(name).toLowerCase(Locale.ROOT);
 
             for (var subCommand : subCommands) {
                 if (subCommand.getName().equals(name) || subCommand.getAliases().contains(name)) {

--- a/api/src/main/java/net/okocraft/box/api/event/feature/FeatureEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/feature/FeatureEvent.java
@@ -4,6 +4,8 @@ import net.okocraft.box.api.event.BoxEvent;
 import net.okocraft.box.api.feature.BoxFeature;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A class that represents a {@link BoxFeature} related event.
  */
@@ -19,8 +21,8 @@ public class FeatureEvent extends BoxEvent {
      * @param type    the type of this event
      */
     public FeatureEvent(@NotNull BoxFeature feature, @NotNull Type type) {
-        this.feature = feature;
-        this.type = type;
+        this.feature = Objects.requireNonNull(feature);
+        this.type = Objects.requireNonNull(type);
     }
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/event/item/ItemImportEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/item/ItemImportEvent.java
@@ -3,6 +3,8 @@ package net.okocraft.box.api.event.item;
 import net.okocraft.box.api.model.item.BoxItem;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A event called when the {@link BoxItem} is imported.
  * <p>
@@ -20,7 +22,7 @@ public class ItemImportEvent extends ItemEvent {
      */
     public ItemImportEvent(@NotNull BoxItem importedItem, @NotNull ItemType type) {
         super(importedItem);
-        this.type = type;
+        this.type = Objects.requireNonNull(type);
     }
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/event/player/PlayerEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/player/PlayerEvent.java
@@ -4,6 +4,8 @@ import net.okocraft.box.api.event.BoxEvent;
 import net.okocraft.box.api.player.BoxPlayer;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A class that represents a {@link BoxPlayer} related event.
  */
@@ -17,7 +19,7 @@ public class PlayerEvent extends BoxEvent {
      * @param boxPlayer the player of this event
      */
     public PlayerEvent(@NotNull BoxPlayer boxPlayer) {
-        this.boxPlayer = boxPlayer;
+        this.boxPlayer = Objects.requireNonNull(boxPlayer);
     }
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/event/player/PlayerStockHolderChangeEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/player/PlayerStockHolderChangeEvent.java
@@ -4,6 +4,8 @@ import net.okocraft.box.api.model.stock.StockHolder;
 import net.okocraft.box.api.player.BoxPlayer;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A {@link PlayerEvent} called when the player changed the {@link StockHolder}.
  */
@@ -20,7 +22,7 @@ public class PlayerStockHolderChangeEvent extends PlayerEvent {
     public PlayerStockHolderChangeEvent(@NotNull BoxPlayer boxPlayer,
                                         @NotNull StockHolder previous) {
         super(boxPlayer);
-        this.previous = previous;
+        this.previous = Objects.requireNonNull(previous);
     }
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/event/stock/StockEvent.java
+++ b/api/src/main/java/net/okocraft/box/api/event/stock/StockEvent.java
@@ -5,6 +5,8 @@ import net.okocraft.box.api.model.stock.StockHolder;
 import net.okocraft.box.api.model.stock.UserStockHolder;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A class that represents a {@link StockHolder} related event.
  * <p>
@@ -23,7 +25,7 @@ public class StockEvent extends BoxEvent {
      * @param stockHolder the stockholder of the event
      */
     public StockEvent(@NotNull StockHolder stockHolder) {
-        this.stockHolder = stockHolder;
+        this.stockHolder = Objects.requireNonNull(stockHolder);
     }
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/feature/AbstractBoxFeature.java
+++ b/api/src/main/java/net/okocraft/box/api/feature/AbstractBoxFeature.java
@@ -3,6 +3,8 @@ package net.okocraft.box.api.feature;
 import com.github.siroshun09.event4j.handlerlist.Key;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * An abstract implementation of {@link BoxFeature}.
  */
@@ -17,7 +19,7 @@ public abstract class AbstractBoxFeature implements BoxFeature {
      * @param name the feature name
      */
     protected AbstractBoxFeature(@NotNull String name) {
-        this.name = name;
+        this.name = Objects.requireNonNull(name);
         this.listenerKey = Key.of(name);
     }
 

--- a/api/src/main/java/net/okocraft/box/api/transaction/InventoryTransaction.java
+++ b/api/src/main/java/net/okocraft/box/api/transaction/InventoryTransaction.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 import static net.okocraft.box.api.transaction.TransactionResultType.DEPOSITED;
 import static net.okocraft.box.api.transaction.TransactionResultType.IS_AIR;
@@ -29,6 +30,8 @@ public final class InventoryTransaction {
      * @return the {@link TransactionResult}
      */
     public static @NotNull TransactionResult depositItemInMainHand(@NotNull Player player, int depositLimit) {
+        Objects.requireNonNull(player);
+
         if (depositLimit < 1) {
             return TransactionResult.create(NOT_DEPOSITED);
         }
@@ -65,6 +68,8 @@ public final class InventoryTransaction {
      * @return the {@link TransactionResultList}
      */
     public static @NotNull TransactionResultList depositItemsInInventory(@NotNull Inventory inventory) {
+        Objects.requireNonNull(inventory);
+
         var result = new ArrayList<TransactionResult>();
         var contents = inventory.getStorageContents();
 
@@ -100,7 +105,10 @@ public final class InventoryTransaction {
      * @return the {@link TransactionResultList}
      */
     public static @NotNull TransactionResultList depositItem(@NotNull Inventory inventory,
-                                                      @NotNull BoxItem boxItem, int depositLimit) {
+                                                             @NotNull BoxItem boxItem, int depositLimit) {
+        Objects.requireNonNull(inventory);
+        Objects.requireNonNull(boxItem);
+
         if (depositLimit < 1) {
             return TransactionResultList.create(NOT_DEPOSITED);
         }
@@ -153,12 +161,15 @@ public final class InventoryTransaction {
      * Withdraws items to an inventory.
      *
      * @param inventory the target inventory
-     * @param boxItem the item to withdraw
-     * @param amount the amount of item
+     * @param boxItem   the item to withdraw
+     * @param amount    the amount of item
      * @return the {@link TransactionResult}
      */
     public static @NotNull TransactionResult withdraw(@NotNull Inventory inventory,
-                                               @NotNull BoxItem boxItem, int amount) {
+                                                      @NotNull BoxItem boxItem, int amount) {
+        Objects.requireNonNull(inventory);
+        Objects.requireNonNull(boxItem);
+
         var toStore = amount;
         var maxStackSize = boxItem.getOriginal().getMaxStackSize();
 

--- a/api/src/main/java/net/okocraft/box/api/transaction/TransactionResult.java
+++ b/api/src/main/java/net/okocraft/box/api/transaction/TransactionResult.java
@@ -21,6 +21,8 @@ public class TransactionResult {
      */
     @Contract(value = "_ -> new", pure = true)
     public static @NotNull TransactionResult create(@NotNull TransactionResultType type) {
+        Objects.requireNonNull(type);
+
         if (!type.isModified()) {
             return new TransactionResult(type, null, 0);
         } else {
@@ -40,6 +42,9 @@ public class TransactionResult {
      */
     @Contract(value = "_, _, _ -> new", pure = true)
     public static @NotNull TransactionResult create(@NotNull TransactionResultType type, @NotNull BoxItem item, int amount) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(item);
+
         if (type.isModified()) {
             return new TransactionResult(type, item, amount);
         } else {

--- a/api/src/main/java/net/okocraft/box/api/transaction/TransactionResultList.java
+++ b/api/src/main/java/net/okocraft/box/api/transaction/TransactionResultList.java
@@ -22,6 +22,8 @@ public class TransactionResultList {
      */
     @Contract(value = "_ -> new", pure = true)
     public static @NotNull TransactionResultList create(@NotNull TransactionResultType type) {
+        Objects.requireNonNull(type);
+
         if (!type.isModified()) {
             return new TransactionResultList(type, null);
         } else {
@@ -41,6 +43,9 @@ public class TransactionResultList {
     @Contract(value = "_, _ -> new", pure = true)
     public static @NotNull TransactionResultList create(@NotNull TransactionResultType type,
                                                         @NotNull List<TransactionResult> resultList) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(resultList);
+
         if (type.isModified()) {
             return new TransactionResultList(type, resultList);
         } else {

--- a/core/src/main/java/net/okocraft/box/core/command/BaseCommand.java
+++ b/core/src/main/java/net/okocraft/box/core/command/BaseCommand.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.logging.Level;
 
 import static net.kyori.adventure.text.Component.text;
@@ -32,6 +33,9 @@ public abstract class BaseCommand implements Command, SubCommandHoldable, Comman
 
     @Override
     public void onCommand(@NotNull CommandSender sender, @NotNull String[] args) {
+        Objects.requireNonNull(sender);
+        Objects.requireNonNull(args);
+
         if (!sender.hasPermission(getPermissionNode())) {
             sender.sendMessage(GeneralMessage.ERROR_NO_PERMISSION.apply(getPermissionNode()));
             return;
@@ -73,6 +77,9 @@ public abstract class BaseCommand implements Command, SubCommandHoldable, Comman
 
     @Override
     public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+        Objects.requireNonNull(sender);
+        Objects.requireNonNull(args);
+
         if (args.length == 0 || !sender.hasPermission(getPermissionNode())) {
             return Collections.emptyList();
         }

--- a/core/src/main/java/net/okocraft/box/core/model/data/BoxCustomDataContainer.java
+++ b/core/src/main/java/net/okocraft/box/core/model/data/BoxCustomDataContainer.java
@@ -6,6 +6,7 @@ import net.okocraft.box.core.storage.model.data.CustomDataStorage;
 import net.okocraft.box.core.util.executor.InternalExecutors;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -21,6 +22,9 @@ public class BoxCustomDataContainer implements CustomDataContainer {
 
     @Override
     public @NotNull CompletableFuture<@NotNull Configuration> get(@NotNull String namespace, @NotNull String key) {
+        Objects.requireNonNull(namespace);
+        Objects.requireNonNull(key);
+
         return CompletableFuture.supplyAsync(() -> {
             try {
                 return customDataStorage.load(namespace, key);
@@ -32,6 +36,10 @@ public class BoxCustomDataContainer implements CustomDataContainer {
 
     @Override
     public @NotNull CompletableFuture<Void> set(@NotNull String namespace, @NotNull String key, @NotNull Configuration configuration) {
+        Objects.requireNonNull(namespace);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(configuration);
+
         return CompletableFuture.runAsync(() -> {
             try {
                 customDataStorage.save(namespace, key, configuration);

--- a/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
+++ b/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -39,7 +40,7 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public @NotNull Optional<BoxItem> getBoxItem(@NotNull ItemStack itemStack) {
-        var copied = itemStack.clone();
+        var copied = Objects.requireNonNull(itemStack).clone();
 
         copied.setAmount(1);
 
@@ -48,7 +49,7 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public @NotNull Optional<BoxItem> getBoxItem(@NotNull String name) {
-        name = name.toUpperCase(Locale.ROOT);
+        name = Objects.requireNonNull(name).toUpperCase(Locale.ROOT);
 
         for (var item : itemMap.values()) {
             if (item.getPlainName().equals(name)) {
@@ -72,7 +73,7 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public boolean isRegistered(@NotNull ItemStack itemStack) {
-        var copied = itemStack.clone();
+        var copied = Objects.requireNonNull(itemStack).clone();
 
         copied.setAmount(1);
 
@@ -81,6 +82,8 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public boolean isUsed(@NotNull String name) {
+        Objects.requireNonNull(name);
+
         var nameSet = itemNameCache;
         return nameSet.contains(name);
     }
@@ -92,6 +95,8 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public @NotNull CompletableFuture<@NotNull BoxCustomItem> registerCustomItem(@NotNull ItemStack original) {
+        Objects.requireNonNull(original);
+
         return CompletableFuture.supplyAsync(() -> {
             var copied = original.clone();
 
@@ -119,7 +124,11 @@ public class BoxItemManager implements ItemManager {
     }
 
     @Override
-    public @NotNull CompletableFuture<@NotNull BoxCustomItem> renameCustomItem(@NotNull BoxCustomItem item, @NotNull String newName) {
+    public @NotNull CompletableFuture<@NotNull BoxCustomItem> renameCustomItem(@NotNull BoxCustomItem item,
+                                                                               @NotNull String newName) {
+        Objects.requireNonNull(item);
+        Objects.requireNonNull(newName);
+
         return CompletableFuture.supplyAsync(() -> {
             if (!isCustomItem(item)) {
                 throw new IllegalStateException("Could not rename item because the item is created by box.");

--- a/core/src/main/java/net/okocraft/box/core/model/manager/BoxStockManager.java
+++ b/core/src/main/java/net/okocraft/box/core/model/manager/BoxStockManager.java
@@ -7,6 +7,7 @@ import net.okocraft.box.core.storage.model.stock.StockStorage;
 import net.okocraft.box.core.util.executor.InternalExecutors;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -22,6 +23,8 @@ public class BoxStockManager implements StockManager {
 
     @Override
     public @NotNull CompletableFuture<@NotNull UserStockHolder> loadUserStock(@NotNull BoxUser user) {
+        Objects.requireNonNull(user);
+
         return CompletableFuture.supplyAsync(() -> {
             try {
                 return stockStorage.loadUserStockHolder(user);
@@ -33,6 +36,8 @@ public class BoxStockManager implements StockManager {
 
     @Override
     public @NotNull CompletableFuture<Void> saveUserStock(@NotNull UserStockHolder stockHolder) {
+        Objects.requireNonNull(stockHolder);
+
         return CompletableFuture.runAsync(() -> {
             try {
                 stockStorage.saveUserStockHolder(stockHolder);

--- a/core/src/main/java/net/okocraft/box/core/model/manager/BoxUserManager.java
+++ b/core/src/main/java/net/okocraft/box/core/model/manager/BoxUserManager.java
@@ -6,6 +6,7 @@ import net.okocraft.box.core.storage.model.user.UserStorage;
 import net.okocraft.box.core.util.executor.InternalExecutors;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -23,6 +24,8 @@ public class BoxUserManager implements UserManager {
 
     @Override
     public @NotNull CompletableFuture<@NotNull BoxUser> loadUser(@NotNull UUID uuid) {
+        Objects.requireNonNull(uuid);
+
         return CompletableFuture.supplyAsync(() -> {
             try {
                 return userStorage.getUser(uuid);
@@ -34,6 +37,8 @@ public class BoxUserManager implements UserManager {
 
     @Override
     public @NotNull CompletableFuture<Void> saveUser(@NotNull BoxUser boxUser) {
+        Objects.requireNonNull(boxUser);
+
         return CompletableFuture.runAsync(() -> {
             try {
                 userStorage.saveBoxUser(boxUser);
@@ -45,6 +50,8 @@ public class BoxUserManager implements UserManager {
 
     @Override
     public @NotNull CompletableFuture<Optional<BoxUser>> search(@NotNull String name) {
+        Objects.requireNonNull(name);
+
         return CompletableFuture.supplyAsync(() -> {
             try {
                 return userStorage.search(name);

--- a/core/src/main/java/net/okocraft/box/core/model/stock/AbstractStockHolder.java
+++ b/core/src/main/java/net/okocraft/box/core/model/stock/AbstractStockHolder.java
@@ -33,6 +33,7 @@ public abstract class AbstractStockHolder implements StockHolder {
 
     @Override
     public int getAmount(@NotNull BoxItem item) {
+        Objects.requireNonNull(item);
         return Optional.ofNullable(stockData.get(item)).map(AtomicInteger::get).orElse(0);
     }
 
@@ -126,6 +127,7 @@ public abstract class AbstractStockHolder implements StockHolder {
     }
 
     private @NotNull AtomicInteger getStock(@NotNull BoxItem item) {
+        Objects.requireNonNull(item);
         return stockData.computeIfAbsent(item, i -> new AtomicInteger(0));
     }
 }

--- a/core/src/main/java/net/okocraft/box/core/player/BoxPlayerMapImpl.java
+++ b/core/src/main/java/net/okocraft/box/core/player/BoxPlayerMapImpl.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,11 +34,15 @@ public class BoxPlayerMapImpl implements BoxPlayerMap {
 
     @Override
     public @NotNull BoxPlayer get(@NotNull Player player) {
+        Objects.requireNonNull(player);
+
         return Optional.ofNullable(playerMap.get(player))
                 .orElseThrow(() -> new IllegalStateException("player is not loaded (" + player.getName() + ")"));
     }
 
     public @NotNull CompletableFuture<Void> load(@NotNull Player player) {
+        Objects.requireNonNull(player);
+
         return CompletableFuture.runAsync(() -> {
             var boxUser = new BoxUserImpl(player.getUniqueId(), player.getName());
 
@@ -54,6 +59,8 @@ public class BoxPlayerMapImpl implements BoxPlayerMap {
     }
 
     public @NotNull CompletableFuture<Void> unload(@NotNull Player player) {
+        Objects.requireNonNull(player);
+
         var boxPlayer = playerMap.remove(player);
 
         if (boxPlayer != null) {

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -6,6 +6,7 @@ import net.okocraft.box.api.taskfactory.TaskFactory;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -27,21 +28,25 @@ public class BoxTaskFactory implements TaskFactory {
 
     @Override
     public @NotNull CompletableFuture<Void> run(@NotNull Runnable task) {
+        Objects.requireNonNull(task);
         return CompletableFuture.runAsync(task, getMainThread());
     }
 
     @Override
     public @NotNull <T> CompletableFuture<T> supply(@NotNull Supplier<T> supplier) {
+        Objects.requireNonNull(supplier);
         return CompletableFuture.supplyAsync(supplier, getMainThread());
     }
 
     @Override
     public @NotNull CompletableFuture<Void> runAsync(@NotNull Runnable task) {
+        Objects.requireNonNull(task);
         return CompletableFuture.runAsync(task, executor);
     }
 
     @Override
     public @NotNull <T> CompletableFuture<T> supplyAsync(@NotNull Supplier<T> supplier) {
+        Objects.requireNonNull(supplier);
         return CompletableFuture.supplyAsync(supplier, executor);
     }
 


### PR DESCRIPTION
api とその実装 (core) に対して null check を追加する。

`@NotNull` である引数に `null` を渡された場合、実際に処理を行う前に `NullPointerException` をスローする。

内部向けのコードには追加しない。他モジュールの API にあたるパッケージには別 PR で今後追加する。

