### PR TITLE
Implements /boxadmin stock

### DIFF
--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -185,6 +185,31 @@ box:
         help:
           command-line: "/boxadmin reset <player>"
           description: "Resets all stock"
+      stock:
+        help:
+          command-line: "/boxadmin stock <info/list> <args>"
+          description: "Shows player's stock"
+        info:
+          amount: "The amount of player {0}''s item {1} : {2}"
+          help:
+            command-line: "/boxadmin stock info <player> <item name>"
+            description: "Shows the amount of stock"
+        list:
+          header: "Player {0}''s stock list (Page {1}/{2})"
+          amount: "{0}. {1} - {2}"
+          help:
+            command-line: "/boxadmin stock list <player> {args}"
+            description: "Shows the stock list"
+            argument:
+              sorter:
+                format: "{0} ({1}) {2} - Specifies the order of stock"
+                value: "<sort>"
+              page:
+                format: "{0} ({1}) {2} - Specifies the page"
+                value: "<page>"
+              filter:
+                format: "{0} ({1}) {2} - Filters items"
+                value: "<item name>"
       set:
         success:
           sender: "Player {0}''s item {1} has been set to {2}."

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -185,6 +185,31 @@ box:
         help:
           command-line: "/boxadmin reset <プレイヤー名>"
           description: "在庫をすべてリセットする"
+      stock:
+        help:
+          command-line: "/boxadmin stock <info/list> <引数>"
+          description: "在庫情報を表示する"
+        info:
+          amount: "プレイヤー {0} のアイテム {1} の在庫: {2} 個"
+          help:
+            command-line: "/boxadmin stock info <プレイヤー名> <アイテム名>"
+            description: "在庫数を表示する"
+        list:
+          header: "プレイヤー {0} の在庫リスト ({1}/{2}ページ)"
+          amount: "{0}. {1} - {2} 個"
+          help:
+            command-line: "/boxadmin stock list <プレイヤー名> {引数}"
+            description: "在庫リストを表示する"
+            argument:
+              sorter:
+                format: "{0} ({1}) {2} - 表示順を指定する"
+                value: "<ソート方法>"
+              page:
+                format: "{0} ({1}) {2} - ページを指定する"
+                value: "<ページ数>"
+              filter:
+                 format: "{0} ({1}) {2} - アイテムを絞り込む"
+                 value: "<アイテム名>"
       set:
         success:
           sender: "プレイヤー {0} のアイテム {1} の在庫を {2} 個にセットしました。"

--- a/bundle/src/main/resources/plugin.yml
+++ b/bundle/src/main/resources/plugin.yml
@@ -97,6 +97,9 @@ permissions:
       - box.admin.command.give
       - box.admin.command.set
       - box.admin.command.take
+      - box.admin.command.stock
+      - box.admin.command.stock.info
+      - box.admin.command.stock.list
       - box.admin.command.version
   box.admin.command.customstick:
     default: op
@@ -115,6 +118,12 @@ permissions:
   box.admin.command.set:
     default: op
   box.admin.command.take:
+    default: op
+  box.admin.command.stock:
+    default: op
+  box.admin.command.stock.info:
+    default: op
+  box.admin.command.stock.list:
     default: op
   box.admin.command.version:
     default: op

--- a/features/command/src/main/java/net/okocraft/box/feature/command/CommandFeature.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/CommandFeature.java
@@ -14,6 +14,7 @@ import net.okocraft.box.feature.command.boxadmin.RenameCommand;
 import net.okocraft.box.feature.command.boxadmin.ResetCommand;
 import net.okocraft.box.feature.command.boxadmin.StockModifyCommands;
 import net.okocraft.box.feature.command.boxadmin.VersionCommand;
+import net.okocraft.box.feature.command.boxadmin.stock.StockCommand;
 
 import java.util.List;
 
@@ -25,8 +26,9 @@ public class CommandFeature extends AbstractBoxFeature {
 
     public final List<Command> boxAdminSubCommands =
             List.of(StockModifyCommands.give(), StockModifyCommands.set(), StockModifyCommands.take(),
-                    new InfinityCommand(), new RegisterCommand(), new RenameCommand(),
-                    new ReloadCommand(), new ResetCommand(), new VersionCommand());
+                    new StockCommand(), new InfinityCommand(), new RegisterCommand(),
+                    new RenameCommand(), new ReloadCommand(), new ResetCommand(),
+                    new VersionCommand());
 
     public CommandFeature() {
         super("command");

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/stock/StockCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/stock/StockCommand.java
@@ -1,0 +1,88 @@
+package net.okocraft.box.feature.command.boxadmin.stock;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.okocraft.box.api.command.AbstractCommand;
+import net.okocraft.box.api.command.Command;
+import net.okocraft.box.api.command.SubCommandHoldable;
+import net.okocraft.box.api.message.GeneralMessage;
+import net.okocraft.box.feature.command.message.BoxAdminMessage;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public class StockCommand extends AbstractCommand implements SubCommandHoldable {
+
+    private final SubCommandHolder subCommandHolder = new SubCommandHolder();
+
+    public StockCommand() {
+        // The alias should be "s", but it is already used, so we use "st".
+        super("stock", "box.admin.command.stock", Set.of("st"));
+        subCommandHolder.register(new StockInfoCommand());
+        subCommandHolder.register(new StockListCommand());
+    }
+
+    @Override
+    public @NotNull Component getHelp() {
+        return BoxAdminMessage.STOCK_HELP
+                .append(Component.newline())
+                .append(
+                        Component.join(
+                                JoinConfiguration.separator(Component.newline()),
+                                subCommandHolder.getSubCommands().stream().map(Command::getHelp).toList()
+                        )
+                );
+    }
+
+    @Override
+    public void onCommand(@NotNull CommandSender sender, @NotNull String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage(GeneralMessage.ERROR_COMMAND_NOT_ENOUGH_ARGUMENT);
+            sender.sendMessage(getHelp());
+            return;
+        }
+
+        var optionalSubCommand = subCommandHolder.search(args[1]);
+
+        if (optionalSubCommand.isEmpty()) {
+            if (!args[1].equalsIgnoreCase("help")) {
+                sender.sendMessage(GeneralMessage.ERROR_COMMAND_SUBCOMMAND_NOT_FOUND);
+            }
+            sender.sendMessage(getHelp());
+            return;
+        }
+
+        var subCommand = optionalSubCommand.get();
+
+        if (sender.hasPermission(subCommand.getPermissionNode())) {
+            subCommand.onCommand(sender, args);
+        } else {
+            sender.sendMessage(GeneralMessage.ERROR_NO_PERMISSION.apply(subCommand.getPermissionNode()));
+        }
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+        if (args.length == 2) {
+            return subCommandHolder.getSubCommands().stream()
+                    .filter(cmd -> sender.hasPermission(cmd.getPermissionNode()))
+                    .map(Command::getName)
+                    .filter(cmdName -> cmdName.startsWith(args[1].toLowerCase(Locale.ROOT)))
+                    .toList();
+        } else {
+            return subCommandHolder.search(args[1])
+                    .filter(cmd -> sender.hasPermission(cmd.getPermissionNode()))
+                    .map(cmd -> cmd.onTabComplete(sender, args))
+                    .orElse(Collections.emptyList());
+        }
+    }
+
+    @Override
+    public @NotNull SubCommandHolder getSubCommandHolder() {
+        return subCommandHolder;
+    }
+}

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/stock/StockInfoCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/stock/StockInfoCommand.java
@@ -1,0 +1,66 @@
+package net.okocraft.box.feature.command.boxadmin.stock;
+
+import net.kyori.adventure.text.Component;
+import net.okocraft.box.api.BoxProvider;
+import net.okocraft.box.api.command.AbstractCommand;
+import net.okocraft.box.api.message.GeneralMessage;
+import net.okocraft.box.feature.command.message.BoxAdminMessage;
+import net.okocraft.box.feature.command.util.TabCompleter;
+import net.okocraft.box.feature.command.util.UserStockHolderOperator;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class StockInfoCommand extends AbstractCommand {
+
+    public StockInfoCommand() {
+        super("info", "box.admin.command.stock.info", Set.of("i"));
+    }
+
+    @Override
+    public @NotNull Component getHelp() {
+        return BoxAdminMessage.STOCK_INFO_HELP;
+    }
+
+    @Override
+    public void onCommand(@NotNull CommandSender sender, @NotNull String[] args) {
+        if (args.length < 4) {
+            sender.sendMessage(GeneralMessage.ERROR_COMMAND_NOT_ENOUGH_ARGUMENT);
+            sender.sendMessage(getHelp());
+            return;
+        }
+
+        var boxItem = BoxProvider.get().getItemManager().getBoxItem(args[3]);
+
+        if (boxItem.isEmpty()) {
+            sender.sendMessage(GeneralMessage.ERROR_COMMAND_ITEM_NOT_FOUND.apply(args[3]));
+            return;
+        }
+
+        UserStockHolderOperator.create(args[2])
+                .supportOffline(true)
+                .stockHolderOperator(target -> {
+                    var message =
+                            BoxAdminMessage.STOCK_INFO_AMOUNT.apply(target.getName(), boxItem.get(), target.getAmount(boxItem.get()));
+                    sender.sendMessage(message);
+                })
+                .onNotFound(name -> sender.sendMessage(GeneralMessage.ERROR_COMMAND_PLAYER_NOT_FOUND.apply(name)))
+                .run();
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+        if (args.length == 3) {
+            return TabCompleter.players(args[2]);
+        }
+
+        if (args.length == 4) {
+            return TabCompleter.itemNames(args[3]);
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/stock/StockListCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/stock/StockListCommand.java
@@ -1,0 +1,239 @@
+package net.okocraft.box.feature.command.boxadmin.stock;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.okocraft.box.api.command.AbstractCommand;
+import net.okocraft.box.api.message.GeneralMessage;
+import net.okocraft.box.api.model.stock.StockData;
+import net.okocraft.box.feature.command.message.BoxAdminMessage;
+import net.okocraft.box.feature.command.util.TabCompleter;
+import net.okocraft.box.feature.command.util.UserStockHolderOperator;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class StockListCommand extends AbstractCommand {
+
+    private static final Map<String, ArgumentType> ARGUMENT_MAP;
+
+    static {
+        var map = new HashMap<String, ArgumentType>();
+
+        for (var arg : ArgumentType.values()) {
+            map.put("--" + arg.getLongArg(), arg);
+            map.put("-" + arg.getShortArg(), arg);
+        }
+
+        ARGUMENT_MAP = Collections.unmodifiableMap(map);
+    }
+
+    public StockListCommand() {
+        super("list", "box.admin.command.stock.list", Set.of("l"));
+    }
+
+    @Override
+    public @NotNull Component getHelp() {
+        return BoxAdminMessage.STOCK_LIST_HELP;
+    }
+
+    @Override
+    public void onCommand(@NotNull CommandSender sender, @NotNull String[] args) {
+        if (args.length < 3) {
+            sender.sendMessage(GeneralMessage.ERROR_COMMAND_NOT_ENOUGH_ARGUMENT);
+            sender.sendMessage(getHelp());
+            return;
+        }
+
+        var targetStockHolder = UserStockHolderOperator.create(args[2]).supportOffline(true).getUserStockHolder();
+
+        if (targetStockHolder == null) {
+            sender.sendMessage(GeneralMessage.ERROR_COMMAND_PLAYER_NOT_FOUND.apply(args[2]));
+            return;
+        }
+
+        var context = new Context();
+
+        if (3 < args.length) {
+            ArgumentType type = null;
+            for (var arg : Arrays.copyOfRange(args, 3, args.length)) {
+                if (type != null) {
+                    type.getContextConsumer().accept(arg, context);
+                    type = null;
+                } else {
+                    type = ARGUMENT_MAP.get(arg.toLowerCase(Locale.ENGLISH));
+                }
+            }
+        }
+
+        var stockDataCollection = targetStockHolder.toStockDataCollection();
+
+        var sorter = context.getSorter();
+        var filter = context.getFilter();
+
+        if (sorter != null || (filter != null && !filter.isEmpty())) {
+            var stream = stockDataCollection.stream();
+
+            if (sorter != null) {
+                stream = stream.sorted(sorter);
+            }
+
+            if (filter != null && !filter.isEmpty()) {
+                stream = stream.filter(stock -> stock.item().getPlainName().startsWith(filter));
+            }
+
+            stockDataCollection = stream.toList();
+        }
+
+        int maxPage = stockDataCollection.size() / 8 + 1;
+        int page = Math.max(Math.min(context.getPage(), maxPage), 1);
+
+        int start = (page - 1) * 8;
+        var counter = new AtomicInteger(start);
+
+        var result =
+                stockDataCollection.stream()
+                        .skip(start)
+                        .limit(8)
+                        .map(stock -> BoxAdminMessage.STOCK_LIST_ITEM_AMOUNT.apply(counter.incrementAndGet(), stock))
+                        .toList();
+
+        sender.sendMessage(
+                BoxAdminMessage.STOCK_LIST_HEADER
+                        .apply(targetStockHolder, page, maxPage)
+                        .append(Component.newline())
+                        .append(Component.join(JoinConfiguration.separator(Component.newline()), result))
+        );
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+        if (args.length < 3) {
+            return Collections.emptyList();
+        }
+
+        if (args.length == 3) {
+            return TabCompleter.players(args[2]);
+        }
+
+        if (args.length == 4) {
+            return List.copyOf(ARGUMENT_MAP.keySet());
+        }
+
+        int index = args.length - 1;
+        var type = ARGUMENT_MAP.get(args[index - 1]);
+
+        if (type != null) {
+            return type.getTabCompleter().apply(args[index]);
+        } else {
+            return List.copyOf(ARGUMENT_MAP.keySet());
+        }
+    }
+
+    private static class Context {
+
+        private static final Comparator<StockData> NAME_ASC = Comparator.comparing(stock -> stock.item().getPlainName());
+        private static final Comparator<StockData> NAME_DESC = NAME_ASC.reversed();
+        private static final Comparator<StockData> AMOUNT_ASC = Comparator.comparing(StockData::amount);
+        private static final Comparator<StockData> AMOUNT_DESC = AMOUNT_ASC.reversed();
+
+        private Comparator<StockData> sorter;
+        private int page;
+        private String filter;
+
+        private Context() {
+        }
+
+        public @Nullable Comparator<StockData> getSorter() {
+            return sorter;
+        }
+
+        public void setSorter(Comparator<StockData> sorter) {
+            this.sorter = sorter;
+        }
+
+        public int getPage() {
+            return page;
+        }
+
+        public void setPage(int page) {
+            this.page = page;
+        }
+
+        public @Nullable String getFilter() {
+            return filter;
+        }
+
+        public void setFilter(String filter) {
+            this.filter = filter;
+        }
+    }
+
+    private enum ArgumentType {
+        SORTER(
+                "sorter", "s",
+                (arg, context) -> {
+                    context.setSorter(switch (arg.toLowerCase(Locale.ROOT)) {
+                        case "na", "name-asc" -> Context.NAME_ASC;
+                        case "nd", "name-desc" -> Context.NAME_DESC;
+                        case "aa", "amount-asc" -> Context.AMOUNT_ASC;
+                        case "ad", "amount-desc" -> Context.AMOUNT_DESC;
+                        default -> null;
+                    });
+                },
+                arg -> {
+                    return Stream.of("na", "name-asc", "nd", "name-desc", "aa", "amount-asc", "ad", "amount-desc")
+                            .filter(sorter -> sorter.startsWith(arg.toLowerCase(Locale.ENGLISH)))
+                            .toList();
+                }
+        ),
+        PAGE("page", "p", (arg, context) -> {
+            try {
+                context.setPage(Integer.parseInt(arg));
+            } catch (NumberFormatException ignored) {
+            }
+        }, arg -> Collections.emptyList()),
+        FILTER("filter", "f", (arg, context) -> context.setFilter(arg), TabCompleter::itemNames);
+
+        private final String longArg;
+        private final String shortArg;
+        private final BiConsumer<String, Context> contextConsumer;
+        private final Function<String, List<String>> tabCompleter;
+
+        ArgumentType(@NotNull String longArg, @NotNull String shortArg, @NotNull BiConsumer<String, Context> contextConsumer,
+                     @NotNull Function<String, List<String>> tabCompleter) {
+            this.longArg = longArg;
+            this.shortArg = shortArg;
+            this.contextConsumer = contextConsumer;
+            this.tabCompleter = tabCompleter;
+        }
+
+        public @NotNull String getLongArg() {
+            return longArg;
+        }
+
+        public @NotNull String getShortArg() {
+            return shortArg;
+        }
+
+        public @NotNull BiConsumer<String, Context> getContextConsumer() {
+            return contextConsumer;
+        }
+
+        public @NotNull Function<String, List<String>> getTabCompleter() {
+            return tabCompleter;
+        }
+    }
+}

--- a/features/command/src/main/java/net/okocraft/box/feature/command/message/BoxAdminMessage.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/message/BoxAdminMessage.java
@@ -8,12 +8,14 @@ import net.okocraft.box.api.message.argument.SingleArgument;
 import net.okocraft.box.api.message.argument.TripleArgument;
 import net.okocraft.box.api.model.item.BoxCustomItem;
 import net.okocraft.box.api.model.item.BoxItem;
+import net.okocraft.box.api.model.stock.StockData;
 import net.okocraft.box.api.model.stock.UserStockHolder;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import static net.kyori.adventure.text.Component.newline;
+import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.NamedTextColor.AQUA;
@@ -299,6 +301,85 @@ public final class BoxAdminMessage {
             translatable("box.command.boxadmin.reset.help.command-line", AQUA)
                     .append(text(" - ", DARK_GRAY))
                     .append(translatable("box.command.boxadmin.reset.help.description", GRAY));
+
+    public static final Component STOCK_HELP =
+            translatable("box.command.boxadmin.stock.help.command-line", AQUA)
+                    .append(text(" - ", DARK_GRAY))
+                    .append(translatable("box.command.boxadmin.stock.help.description", GRAY));
+
+    public static final Component STOCK_INFO_HELP =
+            translatable("box.command.boxadmin.stock.info.help.command-line", AQUA)
+                    .append(text(" - ", DARK_GRAY))
+                    .append(translatable("box.command.boxadmin.stock.info.help.description", GRAY));
+
+    public static final TripleArgument<String, BoxItem, Integer> STOCK_INFO_AMOUNT =
+            (targetName, item, amount) ->
+                    translatable()
+                            .key("box.command.boxadmin.stock.info.amount")
+                            .args(
+                                    text(targetName, AQUA),
+                                    item.getDisplayName().color(AQUA).hoverEvent(item.getOriginal()),
+                                    text(amount, AQUA)
+                            )
+                            .color(GRAY)
+                            .build();
+
+    public static final Component STOCK_LIST_HELP =
+            text().append(translatable("box.command.boxadmin.stock.list.help.command-line", AQUA))
+                    .append(text(" - ", DARK_GRAY))
+                    .append(translatable("box.command.boxadmin.stock.list.help.description", GRAY))
+                    .append(newline()).append(space())
+                    .append(
+                            translatable()
+                                    .key("box.command.boxadmin.stock.list.help.argument.sorter.format")
+                                    .args(
+                                            text("-s", AQUA), text("--sorter", AQUA),
+                                            translatable("box.command.boxadmin.stock.list.help.argument.sorter.value", AQUA)
+                                    )
+                                    .color(GRAY)
+                    ).append(newline()).append(space())
+                    .append(
+                            translatable()
+                                    .key("box.command.boxadmin.stock.list.help.argument.page.format")
+                                    .args(
+                                            text("-p", AQUA), text("--page", AQUA),
+                                            translatable("box.command.boxadmin.stock.list.help.argument.page.value", AQUA)
+                                    )
+                                    .color(GRAY)
+                    ).append(newline()).append(space())
+                    .append(
+                            translatable()
+                                    .key("box.command.boxadmin.stock.list.help.argument.filter.format")
+                                    .args(
+                                            text("-f", AQUA), text("--filter", AQUA),
+                                            translatable("box.command.boxadmin.stock.list.help.argument.page.value", AQUA)
+                                    )
+                                    .color(GRAY)
+                    ).build();
+
+    public static final TripleArgument<UserStockHolder, Integer, Integer> STOCK_LIST_HEADER =
+            (target, page, maxPage) ->
+                    translatable()
+                            .key("box.command.boxadmin.stock.list.header")
+                            .args(
+                                    text(target.getName(), AQUA),
+                                    text(page, AQUA),
+                                    text(maxPage, AQUA)
+                            )
+                            .color(GRAY)
+                            .build();
+
+    public static final DoubleArgument<Integer, StockData> STOCK_LIST_ITEM_AMOUNT =
+            (num, stockData) ->
+                    translatable()
+                            .key("box.command.boxadmin.stock.list.amount")
+                            .args(
+                                    text(num, GRAY),
+                                    stockData.item().getDisplayName().color(AQUA).hoverEvent(stockData.item().getOriginal()),
+                                    text(stockData.amount(), AQUA)
+                            )
+                            .color(GRAY)
+                            .build();
 
     private BoxAdminMessage() {
         throw new UnsupportedOperationException();

--- a/features/command/src/main/java/net/okocraft/box/feature/command/util/UserStockHolderOperator.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/util/UserStockHolderOperator.java
@@ -58,7 +58,7 @@ public class UserStockHolderOperator {
         }
     }
 
-    private @Nullable UserStockHolder getUserStockHolder() {
+    public @Nullable UserStockHolder getUserStockHolder() {
         UUID uuid = null;
 
         try {


### PR DESCRIPTION
#73 の `/boxadmin stockinfo` を改善したもの。

## 追加コマンド

- `/ba stock <info/list> <args>`
- `/ba stock info <player> <item>` - 指定したプレイヤーのアイテム数を表示する
- `/ba stock list <player> {args}` - 指定したプレイヤーの在庫リストを表示する
  - 引数
    - `-s <ソート方法>`  (`--sort`) - 在庫の表示順
      - `na` `name-asc` - アイテム名の昇順 (A-Z)
      - `nd` `name-desc` - アイテム名の降順 (Z-A)
      - `aa` `amount-asc` - 在庫数の昇順 (少ない順)
      - `ad` `amount-desc` - 在庫数の降順 (多い順)
    - `-p <ページ>`  (`--page`) - ページを指定する
    - `-f <フィルター>` (`--filter`) - 指定した文字列から始まるアイテムに絞る

## 検討事項

既存の `/ba give` `/ba set` `/ba take` は在庫を操作するコマンドであるため、`/ba stock give` のようにするべきである

しかし、v4 でリリースする以上コマンドの記法を変更するのはちょっとアレなので v5 に回したいところ