### PR TITLE
Update TranslationLoader and ConfigAPI

### DIFF
--- a/build-logic/src/main/kotlin/box.dependencies.gradle.kts
+++ b/build-logic/src/main/kotlin/box.dependencies.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.siroshun09.configapi:configapi-yaml:4.5.0")
+    implementation("com.github.siroshun09.configapi:configapi-yaml:4.6.0")
     implementation("com.github.siroshun09.event4j:event4j:2.2.0")
 
     compileOnly("io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT")

--- a/bundle/build.gradle.kts
+++ b/bundle/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 tasks.named<Copy>("processResources") {
-    filesMatching("plugin.yml") {
+    filesMatching(listOf("plugin.yml", "en.yml", "ja_JP.yml")) {
         expand("projectVersion" to project.version)
     }
 }

--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -1,3 +1,4 @@
+v: "${projectVersion}"
 box:
   autostore:
     error:

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -1,3 +1,4 @@
+v: "${projectVersion}"
 box:
   autostore:
     error:

--- a/bundle/src/main/resources/plugin.yml
+++ b/bundle/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Box
 main: net.okocraft.box.bundle.BoxBootstrap
-version: ${projectVersion}
+version: "${projectVersion}"
 authors: [ lazy_gon, Siroshun09 ]
 api-version: 1.17
 commands:

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation("com.github.siroshun09.translationloader:translationloader:1.1.1")
+    implementation("com.github.siroshun09.translationloader:translationloader:2.0.0")
     compileOnly(project(":api"))
 }


### PR DESCRIPTION
[TranslationLoader](https://github.com/Siroshun09/TranslationLoader) と [ConfigAPI](https://github.com/Siroshun09/ConfigAPI) を更新して、言語ファイルで欠落しているメッセージを自動追加させる機能を実装する PR。

言語ファイルにバージョンを保存して、プラグインバージョンと異なった場合にアップデートを試みる。

具体的には、Jar に入っている言語ファイルと `Box/languages` 下にあるファイルを比較して、前者にあって後者にないメッセージを後者に追加させる。追加後、バージョン情報とともに Yaml へ再保存する。

※ 再保存するデメリットとして、言語ファイル内の記述の順番が変わることが挙げられるが、メッセージが存在せずチャット欄にキーが表示されるよりはマシなので、この機能を導入する
