### PR TITLE
Add config for craft feature

### DIFF
--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/CraftFeature.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/CraftFeature.java
@@ -1,5 +1,7 @@
 package net.okocraft.box.feature.craft;
 
+import com.github.siroshun09.configapi.api.util.ResourceUtils;
+import com.github.siroshun09.configapi.yaml.YamlConfiguration;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.okocraft.box.api.BoxProvider;
@@ -16,7 +18,9 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
+import java.io.IOException;
 import java.util.Set;
+import java.util.logging.Level;
 
 public class CraftFeature extends AbstractBoxFeature implements Disableable, Reloadable {
 
@@ -29,8 +33,21 @@ public class CraftFeature extends AbstractBoxFeature implements Disableable, Rel
 
     @Override
     public void enable() {
-        RecipeRegistry.setRecipeMap(RecipeLoader.load());
+        var recipeFile = BoxProvider.get().getPluginDirectory().resolve("recipes.yml");
+
+        var recipeConfig = YamlConfiguration.create(recipeFile);
+
+        try {
+            ResourceUtils.copyFromJarIfNotExists(BoxProvider.get().getJar(), "recipes.yml", recipeConfig.getPath());
+            recipeConfig.load();
+        } catch (IOException e) {
+            BoxProvider.get().getLogger().log(Level.SEVERE, "Could not load recipes.yml", e);
+        }
+
+        RecipeRegistry.setRecipeMap(RecipeLoader.load(recipeConfig));
+
         ClickModeRegistry.register(craftMode);
+
         BoxProvider.get().getBoxCommand().getSubCommandHolder().register(craftCommand);
     }
 

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/loader/Processor.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/loader/Processor.java
@@ -1,5 +1,6 @@
 package net.okocraft.box.feature.craft.loader;
 
+import com.github.siroshun09.configapi.api.Configuration;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.model.item.BoxItem;
 import net.okocraft.box.api.model.manager.ItemManager;
@@ -17,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,8 +26,13 @@ final class Processor {
 
     private static final Set<ItemStack> DISABLED_ITEM = Set.of(new ItemStack(Material.FIREWORK_ROCKET));
 
+    private final Configuration recipeConfig;
     private final ItemManager itemManager = BoxProvider.get().getItemManager();
     private final Map<BoxItem, RecipeHolder> recipeMap = new HashMap<>(100, 0.8f);
+
+    Processor(@NotNull Configuration recipeConfig) {
+        this.recipeConfig = recipeConfig;
+    }
 
     void processRecipe(@NotNull Recipe recipe) {
         var item = recipe.getResult().clone();
@@ -52,11 +59,57 @@ final class Processor {
         }
     }
 
+    void processCustomRecipes() {
+        var section = recipeConfig.getSection("custom-recipes");
+
+        if (section == null) {
+            return;
+        }
+
+        var logger = BoxProvider.get().getLogger();
+        var itemManager = BoxProvider.get().getItemManager();
+
+        for (var key : section.getKeyList()) {
+            var ingredients = new ArrayList<BoxItem>();
+
+            for (var ingredientItemName : section.getStringList(key + ".ingredients")) {
+                var item = itemManager.getBoxItem(ingredientItemName);
+
+                if (item.isEmpty()) {
+                    logger.warning("Could not get an ingredient item in recipes.yml (" + ingredientItemName + ")");
+                    ingredients.clear();
+                    break;
+                } else {
+                    ingredients.add(item.get());
+                }
+            }
+
+            if (ingredients.isEmpty()) {
+                continue;
+            }
+
+            var resultItemName = section.getString(key + ".result-item");
+            var resultItem = itemManager.getBoxItem(resultItemName);
+
+            if (resultItem.isEmpty()) {
+                logger.warning("Could not get a result item in recipes.yml (" + resultItemName + ")");
+                continue;
+            }
+
+            var amount = Math.max(1, section.getInteger(key + ".amount"));
+            processCustomRecipe(ingredients, resultItem.get(), amount);
+        }
+    }
+
     @NotNull Map<BoxItem, RecipeHolder> result() {
         return recipeMap;
     }
 
     private void processShapedRecipe(@NotNull ShapedRecipe recipe, @NotNull BoxItem result) {
+        if (recipeConfig.getString("disabled-recipes").contains(recipe.getKey().toString())) {
+            return;
+        }
+
         var ingredients = new ArrayList<IngredientHolder>();
 
         for (var entry : recipe.getChoiceMap().entrySet()) {
@@ -82,6 +135,10 @@ final class Processor {
     }
 
     private void processShapelessRecipe(@NotNull ShapelessRecipe recipe, @NotNull BoxItem result) {
+        if (recipeConfig.getString("disabled-recipes").contains(recipe.getKey().toString())) {
+            return;
+        }
+
         var ingredients = new ArrayList<IngredientHolder>();
 
         int slot = 0;
@@ -104,7 +161,18 @@ final class Processor {
         }
 
         getRecipeHolder(result).addRecipe(new BoxItemRecipe(ingredients, result, recipe.getResult().getAmount()));
+    }
 
+    private void processCustomRecipe(@NotNull List<BoxItem> ingredients, @NotNull BoxItem result, int amount) {
+        var ingredientHolders = new ArrayList<IngredientHolder>();
+
+        int slot = 0;
+        for (var ingredient : ingredients) {
+            ingredientHolders.add(IngredientHolder.fromSingleItem(slot, ingredient.getOriginal()));
+            slot++;
+        }
+
+        getRecipeHolder(result).addRecipe(new BoxItemRecipe(ingredientHolders, result, amount));
     }
 
     @Contract(pure = true)

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/loader/RecipeLoader.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/loader/RecipeLoader.java
@@ -1,5 +1,6 @@
 package net.okocraft.box.feature.craft.loader;
 
+import com.github.siroshun09.configapi.api.Configuration;
 import net.okocraft.box.api.model.item.BoxItem;
 import net.okocraft.box.feature.craft.model.RecipeHolder;
 import org.bukkit.Bukkit;
@@ -9,11 +10,15 @@ import java.util.Map;
 
 public final class RecipeLoader {
 
-    public static @NotNull Map<BoxItem, RecipeHolder> load() {
-        var processor = new Processor();
+    public static @NotNull Map<BoxItem, RecipeHolder> load(@NotNull Configuration recipeConfig) {
+        var processor = new Processor(recipeConfig);
+
         Bukkit.recipeIterator().forEachRemaining(processor::processRecipe);
+
         AdditionalRecipes.RECIPES.forEach(processor::processRecipe);
+
+        processor.processCustomRecipes();
+
         return processor.result();
     }
-
 }

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
@@ -20,6 +20,10 @@ public class IngredientHolder {
         return new IngredientHolder(slot, choice.getChoices());
     }
 
+    public static @NotNull IngredientHolder fromSingleItem(int slot, @NotNull ItemStack itemStack) {
+        return new IngredientHolder(slot, List.of(itemStack));
+    }
+
     private final int slot;
     private final List<BoxIngredientItem> patterns;
 

--- a/features/craft/src/main/resources/recipes.yml
+++ b/features/craft/src/main/resources/recipes.yml
@@ -1,0 +1,17 @@
+# The list to disable default recipes.
+#
+# disabled-recipes:
+# - "minecraft:crossbow"
+#
+disabled-recipes: []
+
+# The list to create custom recipes in Box
+#
+# custom-recipes:
+#   example-name: # WHITE_CONCRETE_POWDER x 1 -> WHITE_CONCRETE x 1
+#     ingredients:
+#       - WHITE_CONCRETE_POWDER
+#     result-item: WHITE_CONCRETE
+#     amount: 1
+#
+custom-recipes: []


### PR DESCRIPTION
`recipes.yml` を追加し、特定レシピの無効化やカスタムなレシピを設定できるようにする。

レシピの無効化には `minecraft:crossbow` のようなレシピのキーを `disabled-recipes` に追加し、カスタムレシピの追加は `recipes.yml` の例に書いてあるように素材・結果・数量を設定する (アイテムは Box での名前)