### PR TITLE
Reduce objects that will be generated while enabling craft feature

### DIFF
--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/CraftFeature.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/CraftFeature.java
@@ -11,6 +11,7 @@ import net.okocraft.box.api.message.Components;
 import net.okocraft.box.feature.craft.command.CraftCommand;
 import net.okocraft.box.feature.craft.loader.RecipeLoader;
 import net.okocraft.box.feature.craft.mode.CraftMode;
+import net.okocraft.box.feature.craft.model.ModelCache;
 import net.okocraft.box.feature.gui.GuiFeature;
 import net.okocraft.box.feature.gui.api.mode.ClickModeRegistry;
 import org.bukkit.command.CommandSender;
@@ -43,7 +44,14 @@ public class CraftFeature extends AbstractBoxFeature implements Disableable, Rel
             BoxProvider.get().getLogger().log(Level.SEVERE, "Could not load recipes.yml", e);
         }
 
+        // Reduce objects that will be generated
+        // BoxIngredientItem 5030 -> 325
+        // IngredientHolder 3506 -> 1417
+        ModelCache.createCache();
+
         var recipeMap = RecipeLoader.load(recipeConfig);
+
+        ModelCache.clearCache();
 
         RecipeRegistry.setRecipeMap(recipeMap);
 

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
@@ -58,6 +58,10 @@ public class IngredientHolder {
         if (o == null || getClass() != o.getClass()) return false;
         IngredientHolder that = (IngredientHolder) o;
 
+        if (slot != that.slot) {
+            return false;
+        }
+
         if (patterns.size() != that.patterns.size()) {
             return false;
         }
@@ -73,7 +77,7 @@ public class IngredientHolder {
 
     @Override
     public int hashCode() {
-        return patterns.hashCode();
+        return Objects.hash(slot, patterns);
     }
 
     public static class SelectableIngredients {

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
@@ -14,28 +14,28 @@ import java.util.Objects;
 public class IngredientHolder {
 
     public static @NotNull IngredientHolder fromMaterialChoice(int slot, @NotNull RecipeChoice.MaterialChoice choice) {
-        return new IngredientHolder(slot, choice.getChoices().stream().map(ItemStack::new).toList());
+        return ModelCache.getIngredientHolder(slot, choice.getChoices().stream().map(ItemStack::new).toList());
     }
 
     public static @NotNull IngredientHolder fromExactChoice(int slot, @NotNull RecipeChoice.ExactChoice choice) {
-        return new IngredientHolder(slot, choice.getChoices());
+        return ModelCache.getIngredientHolder(slot, choice.getChoices());
     }
 
     public static @NotNull IngredientHolder fromSingleItem(int slot, @NotNull ItemStack itemStack) {
-        return new IngredientHolder(slot, List.of(itemStack));
+        return ModelCache.getIngredientHolder(slot, List.of(itemStack));
     }
 
     private final int slot;
     private final List<BoxIngredientItem> patterns;
 
-    private IngredientHolder(int slot, @NotNull List<ItemStack> patterns) {
+    IngredientHolder(int slot, @NotNull List<ItemStack> patterns) {
         this.slot = slot;
 
         var tempPattern = new ArrayList<BoxIngredientItem>();
 
         for (var item : patterns) {
             var boxItem = BoxProvider.get().getItemManager().getBoxItem(item);
-            boxItem.ifPresent(value -> tempPattern.add(new BoxIngredientItem(value, item.getAmount())));
+            boxItem.ifPresent(value -> tempPattern.add(ModelCache.getIngredientItem(value, item.getAmount())));
         }
 
         this.patterns = Collections.unmodifiableList(tempPattern);

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/model/IngredientHolder.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -37,7 +38,7 @@ public class IngredientHolder {
             boxItem.ifPresent(value -> tempPattern.add(new BoxIngredientItem(value, item.getAmount())));
         }
 
-        this.patterns = List.copyOf(tempPattern);
+        this.patterns = Collections.unmodifiableList(tempPattern);
     }
 
     public int getSlot() {

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/model/ModelCache.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/model/ModelCache.java
@@ -1,0 +1,47 @@
+package net.okocraft.box.feature.craft.model;
+
+import net.okocraft.box.api.model.item.BoxItem;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class ModelCache {
+
+    private static Map<BoxItem, BoxIngredientItem> GENERATED_INGREDIENT_ITEMS = null;
+    private static Map<IngredientHolder, IngredientHolder> INGREDIENT_HOLDER_CACHE = null;
+
+    public static void createCache() {
+        GENERATED_INGREDIENT_ITEMS = new HashMap<>(100);
+        INGREDIENT_HOLDER_CACHE = new HashMap<>(300);
+    }
+
+    public static void clearCache() {
+        GENERATED_INGREDIENT_ITEMS = null;
+        INGREDIENT_HOLDER_CACHE = null;
+    }
+
+    static @NotNull BoxIngredientItem getIngredientItem(@NotNull BoxItem item, int amount) {
+        return GENERATED_INGREDIENT_ITEMS != null && amount == 1 ?
+                GENERATED_INGREDIENT_ITEMS.computeIfAbsent(item, ModelCache::createIngredientItem) :
+                new BoxIngredientItem(item, amount);
+    }
+
+    static @NotNull IngredientHolder getIngredientHolder(int slot, @NotNull List<ItemStack> patterns) {
+        var holder = new IngredientHolder(slot, patterns);
+        return INGREDIENT_HOLDER_CACHE != null ?
+                INGREDIENT_HOLDER_CACHE.computeIfAbsent(holder, Function.identity()) :
+                holder;
+    }
+
+    private static @NotNull BoxIngredientItem createIngredientItem(@NotNull BoxItem item) {
+        return new BoxIngredientItem(item, 1);
+    }
+
+    private ModelCache() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
## 概要

craft 機能の起動中に生成されるオブジェクト数を減らし、メモリを削減する。

## 現状

以下は、IntelliJ で起動直後のサーバーのメモリスナップショットを撮ったものである。(`/paper heap` でもダンプファイルを得られる)

![image](https://user-images.githubusercontent.com/39247022/151680813-37020a8b-e8d6-4120-8ac5-43c7552f7cc2.png)
![image](https://user-images.githubusercontent.com/39247022/151680815-db7b4e6c-3776-496f-bae3-9cabdb3c7d45.png)

やたらと craft がメモリを消費しているが、実態は `BoxIngredientItem` や `IngredientHolder` が大半である。

![image](https://user-images.githubusercontent.com/39247022/151680859-92ea9dcb-f8be-4a26-a82b-f016df7ae2df.png)

これはメモリリークではなく、すべてのレシピと、その素材について毎回オブジェクトを生成しているためである。

## 変更後

この PR は、同じ情報を持ったオブジェクトは生成済みのものを返すように変更する。

これにより、`BoxIngredientItem` は 5030 -> 325, `IngredientHolder` は 3506 -> 1417 (数値は生成されたインスタンス数) に削減された。

メモリ使用量の変化は以下の通りである。

![image](https://user-images.githubusercontent.com/39247022/151680975-da7d7ea0-ed6e-4960-ac48-42e6028a68e5.png)

## 変更内容

キャッシュしても、`BoxIngredientItem` と `IngredientHolder` はイミュータブルであるため、問題ない。

### BoxIngredientItem

通常、1スロットに素材として要求されるアイテムの個数は1個であるため、要求個数が1のときにキャッシュを参照・保存する。

個数が1ではない場合は、バニラ状態では起きない。

### IngredientHolder

同じスロットかつ同じ要求アイテムであれば、キャッシュを利用する。

実装上、一旦 `IngredientHolder` のインスタンスを作成しなければならないが、そのうち GC されるので問題なし。