### PR TITLE
ci: use gradle actions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,12 +17,19 @@ jobs:
           distribution: 'temurin'
           java-version: '16'
           cache: 'gradle'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1.0.4
+      - run: chmod +x ./gradlew
       - name: Deploy to staging directory
-        run: |
-          chmod +x ./gradlew
-          ./gradlew clean
-          ./gradlew publish -P box.publish=true
-          ./gradlew aggregateJavadoc
+        uses: gradle/gradle-build-action@v2.1.4
+        with:
+          arguments: |
+            clean
+            publish -P box.publish=true
+      - name: Generate Javadocs
+        uses: gradle/gradle-build-action@v2.1.4
+        with:
+          arguments: aggregateJavadoc
       - name: Move Javadoc pages to staging directory (release)
         if: ${{ github.ref == 'refs/heads/v4/master' }}
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,12 +12,16 @@ jobs:
           distribution: 'temurin'
           java-version: '16'
           cache: 'gradle'
-      - name: Build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew clean
-          ./gradlew build
-          ./gradlew shadowJar
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1.0.4
+      - run: chmod +x ./gradlew
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2.1.4
+        with:
+          arguments: |
+            clean
+            build
+            shadowJar
       - name: Move the artifact
         run: |
           mkdir staging


### PR DESCRIPTION
Use [wrapper-validation-action](https://github.com/gradle/wrapper-validation-action) and [gradle-build-action](https://github.com/gradle/gradle-build-action) as with [okocraft/workflows](https://github.com/okocraft/workflows).