### PR TITLE
Small Improvements (Command)

### DIFF
--- a/api/src/main/java/net/okocraft/box/api/message/Components.java
+++ b/api/src/main/java/net/okocraft/box/api/message/Components.java
@@ -154,6 +154,17 @@ public final class Components {
     }
 
     /**
+     * Creates a white {@link Component} from the key of the message.
+     *
+     * @param key the key of the message
+     * @return the created {@link Component}
+     */
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Component whiteTranslatable(@NotNull String key) {
+        return translatable(key, WHITE);
+    }
+
+    /**
      * Creates a gray {@link Component} from the key of the message and arguments.
      *
      * @param key  the key of the message

--- a/api/src/main/java/net/okocraft/box/api/message/GeneralMessage.java
+++ b/api/src/main/java/net/okocraft/box/api/message/GeneralMessage.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 
 import static net.okocraft.box.api.message.Components.aquaText;
 import static net.okocraft.box.api.message.Components.redTranslatable;
+import static net.okocraft.box.api.message.Components.whiteTranslatable;
 
 /**
  * A class that holds general messages
@@ -73,4 +74,8 @@ public final class GeneralMessage {
     public static final SingleArgument<Player> ERROR_TARGET_PLAYER_NOT_LOADED =
             target -> redTranslatable("box.error.player-data.not-loaded.other", aquaText(target.getName()));
 
+    /**
+     * A component to use to hover text (click to copy).
+     */
+    public static final Component HOVER_TEXT_CLICK_TO_COPY = whiteTranslatable("box.mics.hover-text.click-to-copy");
 }

--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -246,7 +246,7 @@ box:
           command-line: "/boxadmin take <player> <item name> <amount>"
           description: "Decreases stock"
       version:
-        info: "Box {0}"
+        info: "Box Version: {0}"
         help:
           command-line: "/boxadmin version"
           description: "Show the current version of Box"

--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -144,7 +144,8 @@ box:
       iteminfo:
         is-air: "You have no item in your main hand."
         item-not-registered: "The item in your main hand is not registered."
-        name: "Item Name: {0}"
+        name: "Item display name: {0}"
+        id: "Item id: {0}"
         stock: "Current stock: {0}"
         help:
           command-line: "/box iteminfo [item]"

--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -373,3 +373,5 @@ box:
   mics:
     config-reloaded: "config.yml has been reloaded."
     languages-reloaded: "Language files have been reloaded."
+    hover-text:
+      click-to-copy: "Click to copy to clipboard"

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -145,6 +145,7 @@ box:
         is-air: "手に何も持っていません。"
         item-not-registered: "手に持っているアイテムは Box に登録されていません。"
         name: "アイテム登録名: {0}"
+        id: "アイテム ID: {0}"
         stock: "現在の在庫数: {0}"
         help:
           command-line: "/box iteminfo [アイテム名]"

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -246,7 +246,7 @@ box:
           command-line: "/boxadmin take <プレイヤー名> <アイテム名> <数量>"
           description: "在庫を減らす"
       version:
-        info: "Box {0}"
+        info: "Box バージョン: {0}"
         help:
           command-line: "/boxadmin version"
           description: "現在の Box のバージョンを表示する"

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -373,3 +373,5 @@ box:
   mics:
     config-reloaded: "config.yml を再読み込みしました。"
     languages-reloaded: "言語ファイルを再読み込みしました。"
+    hover-text:
+      click-to-copy: "クリックしてクリップボードにコピーする"

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/ItemInfoCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/ItemInfoCommand.java
@@ -60,6 +60,7 @@ public class ItemInfoCommand extends AbstractCommand {
         int stock = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder().getAmount(boxItem);
 
         player.sendMessage(BoxMessage.ITEM_INFO_NAME.apply(boxItem));
+        player.sendMessage(BoxMessage.ITEM_INFO_ID.apply(boxItem.getPlainName()));
         player.sendMessage(BoxMessage.ITEM_INFO_STOCK.apply(stock));
     }
 

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/VersionCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/VersionCommand.java
@@ -1,7 +1,6 @@
 package net.okocraft.box.feature.command.boxadmin;
 
 import net.kyori.adventure.text.Component;
-import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.command.AbstractCommand;
 import net.okocraft.box.feature.command.message.BoxAdminMessage;
 import org.bukkit.command.CommandSender;
@@ -17,7 +16,7 @@ public class VersionCommand extends AbstractCommand {
 
     @Override
     public void onCommand(@NotNull CommandSender sender, @NotNull String[] args) {
-        var version = BoxProvider.get().getPluginInstance().getDescription().getVersion();
+        var version = getClass().getPackage().getImplementationVersion();
         sender.sendMessage(BoxAdminMessage.VERSION_INFO.apply(version));
     }
 

--- a/features/command/src/main/java/net/okocraft/box/feature/command/message/BoxAdminMessage.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/message/BoxAdminMessage.java
@@ -2,6 +2,7 @@ package net.okocraft.box.feature.command.message;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.okocraft.box.api.message.GeneralMessage;
 import net.okocraft.box.api.message.argument.DoubleArgument;
 import net.okocraft.box.api.message.argument.QuadArgument;
 import net.okocraft.box.api.message.argument.SingleArgument;
@@ -33,7 +34,7 @@ public final class BoxAdminMessage {
             version ->
                     grayTranslatable(
                             "box.command.boxadmin.version.info",
-                            aquaText(version)
+                            aquaText(version).clickEvent(ClickEvent.copyToClipboard(version)).hoverEvent(GeneralMessage.HOVER_TEXT_CLICK_TO_COPY)
                     );
 
     public static final Component VERSION_HELP = commandHelp("box.command.boxadmin.version");
@@ -99,7 +100,7 @@ public final class BoxAdminMessage {
             item -> grayTranslatable(
                     "box.command.boxadmin.register.success",
                     aquaItemName(item),
-                    aquaText(item.getPlainName()).clickEvent(ClickEvent.copyToClipboard(item.getPlainName()))
+                    aquaText(item.getPlainName()).clickEvent(ClickEvent.copyToClipboard(item.getPlainName())).hoverEvent(GeneralMessage.HOVER_TEXT_CLICK_TO_COPY)
             );
 
     public static final Component REGISTER_TIP_RENAME = grayTranslatable("box.command.boxadmin.register.tip-rename");

--- a/features/command/src/main/java/net/okocraft/box/feature/command/message/BoxMessage.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/message/BoxMessage.java
@@ -1,6 +1,8 @@
 package net.okocraft.box.feature.command.message;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.okocraft.box.api.message.GeneralMessage;
 import net.okocraft.box.api.message.argument.DoubleArgument;
 import net.okocraft.box.api.message.argument.QuadArgument;
 import net.okocraft.box.api.message.argument.SingleArgument;
@@ -103,6 +105,9 @@ public final class BoxMessage {
 
     public static final SingleArgument<BoxItem> ITEM_INFO_NAME =
             item -> grayTranslatable("box.command.box.iteminfo.name", aquaItemName(item));
+
+    public static final SingleArgument<String> ITEM_INFO_ID =
+            plainName -> grayTranslatable("box.command.box.iteminfo.id", aquaText(plainName).clickEvent(ClickEvent.copyToClipboard(plainName)).hoverEvent(GeneralMessage.HOVER_TEXT_CLICK_TO_COPY));
 
     public static final SingleArgument<Integer> ITEM_INFO_STOCK =
             stock -> grayTranslatable("box.command.box.iteminfo.stock", aquaText(stock));

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/command/StickCommand.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/command/StickCommand.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 
 import static net.okocraft.box.api.message.Components.commandHelp;
+import static net.okocraft.box.api.message.Components.grayTranslatable;
 import static net.okocraft.box.api.message.Components.redTranslatable;
 
 public class StickCommand extends AbstractCommand {
@@ -20,7 +21,7 @@ public class StickCommand extends AbstractCommand {
 
     private static final Component COULD_NOT_GIVE_STICK = redTranslatable("box.stick.command.could-not-give-stick");
 
-    private static final Component GIVE_SUCCESS = redTranslatable("box.stick.command.success");
+    private static final Component GIVE_SUCCESS = grayTranslatable("box.stick.command.success");
 
     private static final Component HELP = commandHelp("box.stick.command");
 


### PR DESCRIPTION
## `/box iteminfo`

Added item id to result.

![image](https://user-images.githubusercontent.com/39247022/198154100-39813dc7-fd07-4cad-bbf8-6600b8235cd2.png)

## `/boxadmin version` 

Made the version clickable (copy to clipboard) and show _Implementation Version_

Example 1: Local Build

![image](https://user-images.githubusercontent.com/39247022/198154623-5e80b747-e578-4220-a5f4-68f05ee29d6b.png)


Example 2: GitHub Actions Build

![image](https://user-images.githubusercontent.com/39247022/198154451-981bd478-63b7-40ad-8f74-c14039b5dd27.png)
