### PR TITLE
Folia

### DIFF
--- a/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
+++ b/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
@@ -1,7 +1,6 @@
 package net.okocraft.box.api.taskfactory;
 
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -21,8 +20,7 @@ public interface TaskFactory {
      * @return the new {@link CompletableFuture}
      * @deprecated not working on Folia
      */
-    @Deprecated(since = "5.3.1", forRemoval = true)
-    @ApiStatus.ScheduledForRemoval(inVersion = "5.4.0")
+    @Deprecated(since = "5.3.1")
     @NotNull CompletableFuture<Void> run(@NotNull Runnable task);
 
     @NotNull CompletableFuture<Void> runTaskForPlayer(@NotNull Player target, @NotNull Consumer<Player> task);
@@ -35,8 +33,7 @@ public interface TaskFactory {
      * @return the new {@link CompletableFuture}
      * @deprecated not working on Folia
      */
-    @Deprecated(since = "5.3.1", forRemoval = true)
-    @ApiStatus.ScheduledForRemoval(inVersion = "5.4.0")
+    @Deprecated(since = "5.3.1")
     <T> @NotNull CompletableFuture<T> supply(@NotNull Supplier<T> supplier);
 
     <T> @NotNull CompletableFuture<T> supplyFromPlayer(@NotNull Player player, @NotNull Function<Player, T> function);

--- a/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
+++ b/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
@@ -1,5 +1,6 @@
 package net.okocraft.box.api.taskfactory;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -15,7 +16,10 @@ public interface TaskFactory {
      *
      * @param task the task to run
      * @return the new {@link CompletableFuture}
+     * @deprecated not working on Folia
      */
+    @Deprecated(since = "5.3.1", forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = "5.4.0")
     @NotNull CompletableFuture<Void> run(@NotNull Runnable task);
 
     /**
@@ -24,7 +28,10 @@ public interface TaskFactory {
      * @param supplier the supplier
      * @param <T>      the value type
      * @return the new {@link CompletableFuture}
+     * @deprecated not working on Folia
      */
+    @Deprecated(since = "5.3.1", forRemoval = true)
+    @ApiStatus.ScheduledForRemoval(inVersion = "5.4.0")
     <T> @NotNull CompletableFuture<T> supply(@NotNull Supplier<T> supplier);
 
     /**

--- a/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
+++ b/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -37,6 +38,8 @@ public interface TaskFactory {
     @Deprecated(since = "5.3.1", forRemoval = true)
     @ApiStatus.ScheduledForRemoval(inVersion = "5.4.0")
     <T> @NotNull CompletableFuture<T> supply(@NotNull Supplier<T> supplier);
+
+    <T> @NotNull CompletableFuture<T> supplyFromPlayer(@NotNull Player player, @NotNull Function<Player, T> function);
 
     /**
      * Creates a {@link CompletableFuture} to run the task asynchronously.

--- a/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
+++ b/api/src/main/java/net/okocraft/box/api/taskfactory/TaskFactory.java
@@ -1,9 +1,11 @@
 package net.okocraft.box.api.taskfactory;
 
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -21,6 +23,8 @@ public interface TaskFactory {
     @Deprecated(since = "5.3.1", forRemoval = true)
     @ApiStatus.ScheduledForRemoval(inVersion = "5.4.0")
     @NotNull CompletableFuture<Void> run(@NotNull Runnable task);
+
+    @NotNull CompletableFuture<Void> runTaskForPlayer(@NotNull Player target, @NotNull Consumer<Player> task);
 
     /**
      * Creates a {@link CompletableFuture} to supply values on main thread.

--- a/api/src/main/java/net/okocraft/box/api/util/Folia.java
+++ b/api/src/main/java/net/okocraft/box/api/util/Folia.java
@@ -2,6 +2,9 @@ package net.okocraft.box.api.util;
 
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * A helper class for checking if the server software is Folia.
+ */
 @ApiStatus.Experimental
 public final class Folia {
 
@@ -20,6 +23,11 @@ public final class Folia {
         RUNNING = isFolia;
     }
 
+    /**
+     * Returns whether the server software is Folia.
+     *
+     * @return {@code true} if the server software is Folia, otherwise {@code false}
+     */
     @ApiStatus.Experimental
     public static boolean check() {
         return RUNNING;

--- a/api/src/main/java/net/okocraft/box/api/util/Folia.java
+++ b/api/src/main/java/net/okocraft/box/api/util/Folia.java
@@ -1,0 +1,27 @@
+package net.okocraft.box.api.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public final class Folia {
+
+    private static final boolean RUNNING;
+
+    static {
+        boolean isFolia;
+
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServerInitEvent");
+            isFolia = true;
+        } catch (ClassNotFoundException e) {
+            isFolia = false;
+        }
+
+        RUNNING = isFolia;
+    }
+
+    @ApiStatus.Experimental
+    public static boolean check() {
+        return RUNNING;
+    }
+}

--- a/bundle/src/main/resources/plugin.yml
+++ b/bundle/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: net.okocraft.box.bundle.BoxBootstrap
 version: "${projectVersion}"
 authors: [ lazy_gon, Siroshun09 ]
 api-version: 1.17
+folia-supported: true
 softdepend: [ CoreProtect, LWC ]
 commands:
   box:

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -1,10 +1,12 @@
 package net.okocraft.box.core.taskfactory;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.taskfactory.TaskFactory;
 import net.okocraft.box.api.util.Folia;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -13,6 +15,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
@@ -31,6 +34,16 @@ public class BoxTaskFactory implements TaskFactory {
     public @NotNull CompletableFuture<Void> run(@NotNull Runnable task) {
         Objects.requireNonNull(task);
         return CompletableFuture.runAsync(task, getMainThread());
+    }
+
+    @Override
+    public @NotNull CompletableFuture<Void> runTaskForPlayer(@NotNull Player target, @NotNull Consumer<Player> task) {
+        Objects.requireNonNull(task);
+        if (Folia.check()) {
+            return CompletableFuture.runAsync(() -> task.accept(target), createExecutorFromEntityScheduler(target.getScheduler()));
+        } else {
+            return CompletableFuture.runAsync(() -> task.accept(target), getMainThread());
+        }
     }
 
     @Override
@@ -75,5 +88,9 @@ public class BoxTaskFactory implements TaskFactory {
             throw new UnsupportedOperationException();
         }
         return Bukkit.getScheduler().getMainThreadExecutor(BoxProvider.get().getPluginInstance());
+    }
+
+    private @NotNull Executor createExecutorFromEntityScheduler(@NotNull EntityScheduler scheduler) {
+        return command -> scheduler.run(BoxProvider.get().getPluginInstance(), $ -> command.run(), null);
     }
 }

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -34,6 +34,11 @@ public class BoxTaskFactory implements TaskFactory {
     @Override
     public @NotNull CompletableFuture<Void> run(@NotNull Runnable task) {
         Objects.requireNonNull(task);
+
+        if (Folia.check()) {
+            throw new UnsupportedOperationException("This method is not supported on Folia.");
+        }
+
         return CompletableFuture.runAsync(task, getMainThread());
     }
 
@@ -50,6 +55,11 @@ public class BoxTaskFactory implements TaskFactory {
     @Override
     public @NotNull <T> CompletableFuture<T> supply(@NotNull Supplier<T> supplier) {
         Objects.requireNonNull(supplier);
+
+        if (Folia.check()) {
+            throw new UnsupportedOperationException("This method is not supported on Folia.");
+        }
+
         return CompletableFuture.supplyAsync(supplier, getMainThread());
     }
 
@@ -97,9 +107,6 @@ public class BoxTaskFactory implements TaskFactory {
     }
 
     public @NotNull Executor getMainThread() {
-        if (Folia.check()) {
-            throw new UnsupportedOperationException();
-        }
         return Bukkit.getScheduler().getMainThreadExecutor(BoxProvider.get().getPluginInstance());
     }
 

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
@@ -50,6 +51,18 @@ public class BoxTaskFactory implements TaskFactory {
     public @NotNull <T> CompletableFuture<T> supply(@NotNull Supplier<T> supplier) {
         Objects.requireNonNull(supplier);
         return CompletableFuture.supplyAsync(supplier, getMainThread());
+    }
+
+    @Override
+    public @NotNull <T> CompletableFuture<T> supplyFromPlayer(@NotNull Player player, @NotNull Function<Player, T> function) {
+        Objects.requireNonNull(player);
+        Objects.requireNonNull(function);
+
+        if (Folia.check()) {
+            return CompletableFuture.supplyAsync(() -> function.apply(player), createExecutorFromEntityScheduler(player.getScheduler()));
+        } else {
+            return CompletableFuture.supplyAsync(() -> function.apply(player), getMainThread());
+        }
     }
 
     @Override

--- a/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
+++ b/core/src/main/java/net/okocraft/box/core/taskfactory/BoxTaskFactory.java
@@ -3,6 +3,7 @@ package net.okocraft.box.core.taskfactory;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.taskfactory.TaskFactory;
+import net.okocraft.box.api.util.Folia;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
@@ -70,6 +71,9 @@ public class BoxTaskFactory implements TaskFactory {
     }
 
     public @NotNull Executor getMainThread() {
+        if (Folia.check()) {
+            throw new UnsupportedOperationException();
+        }
         return Bukkit.getScheduler().getMainThreadExecutor(BoxProvider.get().getPluginInstance());
     }
 }

--- a/features/bemode/src/main/java/net/okocraft/box/feature/bemode/mode/AbstractStorageMode.java
+++ b/features/bemode/src/main/java/net/okocraft/box/feature/bemode/mode/AbstractStorageMode.java
@@ -114,7 +114,7 @@ public abstract class AbstractStorageMode implements BoxItemClickMode {
 
             var resultList =
                     BoxProvider.get().getTaskFactory()
-                            .supply(() -> InventoryTransaction.depositItemsInInventory(clicker.getInventory()))
+                            .supplyFromPlayer(clicker, player -> InventoryTransaction.depositItemsInInventory(player.getInventory()))
                             .join();
 
             if (!resultList.getType().isModified()) {

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/DepositCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/DepositCommand.java
@@ -98,7 +98,7 @@ public class DepositCommand extends AbstractCommand {
     private void depositItemInMainHand(@NotNull Player player, int amount) {
         var result =
                 BoxProvider.get().getTaskFactory()
-                        .supply(() -> InventoryTransaction.depositItemInMainHand(player, amount))
+                        .supplyFromPlayer(player, $player -> InventoryTransaction.depositItemInMainHand($player, amount))
                         .join();
 
         if (result.getType().isModified()) {
@@ -122,7 +122,7 @@ public class DepositCommand extends AbstractCommand {
     private void depositAll(@NotNull Player player) {
         var resultList =
                 BoxProvider.get().getTaskFactory()
-                        .supply(() -> InventoryTransaction.depositItemsInInventory(player.getInventory()))
+                        .supplyFromPlayer(player, $player -> InventoryTransaction.depositItemsInInventory($player.getInventory()))
                         .join();
 
         var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
@@ -137,7 +137,7 @@ public class DepositCommand extends AbstractCommand {
     private void depositItem(@NotNull Player player, @NotNull BoxItem boxItem, int amount) {
         var resultList =
                 BoxProvider.get().getTaskFactory()
-                        .supply(() -> InventoryTransaction.depositItem(player.getInventory(), boxItem, amount))
+                        .supplyFromPlayer(player, $player -> InventoryTransaction.depositItem($player.getInventory(), boxItem, amount))
                         .join();
 
         var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/WithdrawCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/WithdrawCommand.java
@@ -71,7 +71,7 @@ public class WithdrawCommand extends AbstractCommand {
 
         var result =
                 BoxProvider.get().getTaskFactory()
-                        .supply(() -> InventoryTransaction.withdraw(player.getInventory(), boxItem, amount))
+                        .supplyFromPlayer(player, $player -> InventoryTransaction.withdraw($player.getInventory(), boxItem, amount))
                         .join();
 
         var resultType = result.getType();

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/util/ItemCrafter.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/util/ItemCrafter.java
@@ -64,9 +64,9 @@ public class ItemCrafter {
 
         if (Distribution.toInventory(crafter)) {
             var result =
-                    BoxProvider.get().getTaskFactory().supply(
-                            () -> InventoryTransaction.withdraw(crafter.getInventory(), recipe.result(), resultAmount)
-                    ).join();
+                    BoxProvider.get().getTaskFactory()
+                            .supplyFromPlayer(crafter, player -> InventoryTransaction.withdraw(player.getInventory(), recipe.result(), resultAmount))
+                            .join();
 
             if (result.getType().isModified()) {
                 storeAmount = resultAmount - result.getAmount();

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/api/buttons/CloseButton.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/api/buttons/CloseButton.java
@@ -38,7 +38,7 @@ public class CloseButton implements Button {
 
     @Override
     public void onClick(@NotNull Player clicker, @NotNull ClickType clickType) {
-        BoxProvider.get().getTaskFactory().run(clicker::closeInventory);
+        BoxProvider.get().getTaskFactory().runTaskForPlayer(clicker, Player::closeInventory);
         clicker.playSound(clicker.getLocation(), Sound.BLOCK_CHEST_CLOSE, SoundCategory.MASTER, 100f, 1.5f);
     }
 }

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/api/util/MenuOpener.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/api/util/MenuOpener.java
@@ -17,7 +17,7 @@ public final class MenuOpener {
         holder.applyContents();
 
         BoxProvider.get().getTaskFactory()
-                .run(() -> viewer.openInventory(holder.getInventory()))
+                .runTaskForPlayer(viewer, player -> player.openInventory(holder.getInventory()))
                 .join();
 
         if (XmasChecker.isXmas()) {

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/listener/InventoryListener.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/listener/InventoryListener.java
@@ -73,7 +73,7 @@ public class InventoryListener implements Listener {
         holder.processClick(clicker, slot, type);
 
         if (holder.updateMenu(clicker)) {
-            BoxProvider.get().getTaskFactory().run(() -> holder.updateInventory(clicker)).join();
+            BoxProvider.get().getTaskFactory().runTaskForPlayer(clicker, holder::updateInventory).join();
         }
     }
 

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/mode/StorageMode.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/mode/StorageMode.java
@@ -101,9 +101,9 @@ public class StorageMode implements BoxItemClickMode {
         int transactionAmount = session.getCustomNumberHolder(TRANSACTION_AMOUNT_NAME).getAmount();
 
         var resultList =
-                BoxProvider.get().getTaskFactory().supply(
-                        () -> InventoryTransaction.depositItem(player.getInventory(), context.item(), transactionAmount)
-                ).join();
+                BoxProvider.get().getTaskFactory()
+                        .supplyFromPlayer(player, $player -> InventoryTransaction.depositItem($player.getInventory(), context.item(), transactionAmount))
+                        .join();
 
         if (!resultList.getType().isModified()) {
             player.playSound(player.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 100f, 1.5f);
@@ -138,7 +138,7 @@ public class StorageMode implements BoxItemClickMode {
 
         var result =
                 BoxProvider.get().getTaskFactory()
-                        .supply(() -> InventoryTransaction.withdraw(player.getInventory(), context.item(), amount))
+                        .supplyFromPlayer(player, $player -> InventoryTransaction.withdraw($player.getInventory(), context.item(), amount))
                         .join();
 
         if (result.getType().isModified()) {
@@ -184,7 +184,7 @@ public class StorageMode implements BoxItemClickMode {
 
             var resultList =
                     BoxProvider.get().getTaskFactory()
-                            .supply(() -> InventoryTransaction.depositItemsInInventory(clicker.getInventory()))
+                            .supplyFromPlayer(clicker, player -> InventoryTransaction.depositItemsInInventory(player.getInventory()))
                             .join();
 
             if (!resultList.getType().isModified()) {

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/command/CustomStickCommand.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/command/CustomStickCommand.java
@@ -34,7 +34,7 @@ public class CustomStickCommand extends AbstractCommand {
             return;
         }
 
-        BoxProvider.get().getTaskFactory().run(() -> makeStick(player)).join();
+        BoxProvider.get().getTaskFactory().runTaskForPlayer(player, this::makeStick).join();
     }
 
     private void makeStick(@NotNull Player player) {

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/command/StickCommand.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/command/StickCommand.java
@@ -39,7 +39,7 @@ public class StickCommand extends AbstractCommand {
             return;
         }
 
-        BoxProvider.get().getTaskFactory().run(() -> runCommand(player)).join();
+        BoxProvider.get().getTaskFactory().runTaskForPlayer(player, this::runCommand).join();
     }
 
     private void runCommand(@NotNull Player player) {

--- a/features/stick/src/main/java/net/okocraft/box/feature/stick/listener/StickListener.java
+++ b/features/stick/src/main/java/net/okocraft/box/feature/stick/listener/StickListener.java
@@ -2,6 +2,7 @@ package net.okocraft.box.feature.stick.listener;
 
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.player.BoxPlayer;
+import net.okocraft.box.api.util.Folia;
 import net.okocraft.box.api.util.MCDataVersion;
 import net.okocraft.box.feature.stick.event.stock.StickCause;
 import net.okocraft.box.feature.stick.event.stock.StickCauses;
@@ -304,10 +305,14 @@ public class StickListener implements Listener {
 
             // If setConsumeItem is set to false, the arrow will not be picked up.
             // This task overwrites it after 1 tick.
-            Bukkit.getScheduler().runTask(
-                    BoxProvider.get().getPluginInstance(),
-                    () -> arrow.setPickupStatus(AbstractArrow.PickupStatus.ALLOWED)
-            );
+            if (Folia.check()) {
+                arrow.getScheduler().runDelayed(BoxProvider.get().getPluginInstance(), $ -> arrow.setPickupStatus(AbstractArrow.PickupStatus.ALLOWED), null, 1);
+            } else {
+                Bukkit.getScheduler().runTask(
+                        BoxProvider.get().getPluginInstance(),
+                        () -> arrow.setPickupStatus(AbstractArrow.PickupStatus.ALLOWED)
+                );
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
 translationloader = { module = "com.github.siroshun09.translationloader:translationloader", version.ref = "translationloader" }
 
 # platform api
-paper = { module = "io.papermc.paper:paper-api", version.ref = "paper" }
+paper = { module = "dev.folia:folia-api", version.ref = "paper" }
 
 # plugin api
 coreprotect = { module = "net.coreprotect:coreprotect", version.ref = "coreprotect" }


### PR DESCRIPTION
## Changes

- Add `Folia` class for checking if the server software is Folia
- Deprecate `TaskFactory#run` and `TaskFactory#supply` 
  -  These methods throw `UnsupportedOperationException` when running on Folia
- Add `TaskFactory#runTaskForPlayer` and `TaskFactory#supplyFromPlayer`
