### PR TITLE
Argument for Opening the Category Menu

### DIFF
--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -315,6 +315,7 @@ box:
     reloaded: "GUI feature has been reloaded."
     error-occurred: "An error occurred while click process. Error message: {0}"
     cannot-open-menu: "You cannot open the menu now."
+    category-not-found: "The category {0} could not be found."
     command-help:
       command-line: "/box gui"
       description: "Opens Box menu"

--- a/bundle/src/main/resources/en.yml
+++ b/bundle/src/main/resources/en.yml
@@ -66,6 +66,7 @@ box:
     reloaded: "The category feature has been reloaded."
     item-info:
       prefix: "Category"
+      click-to-open: "Click to open the menu"
     name:
       armors: "Armors"
       bows: "Bows"

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -66,6 +66,7 @@ box:
     reloaded: "カテゴリーを再読み込みしました。"
     item-info:
       prefix: "カテゴリー"
+      click-to-open: "クリックしてメニューを開く"
     name:
       armors: "防具"
       bows: "弓矢"

--- a/bundle/src/main/resources/ja_JP.yml
+++ b/bundle/src/main/resources/ja_JP.yml
@@ -315,6 +315,7 @@ box:
     reloaded: "GUI 機能を再読み込みしました。"
     error-occurred: "クリック処理中にエラーが発生しました。エラーメッセージ: {0}"
     cannot-open-menu: "メニューを開けませんでした。"
+    category-not-found: "カテゴリー {0} は見つかりませんでした。"
     command-help:
       command-line: "/box gui"
       description: "Box のメニューを開く"

--- a/features/category/src/main/java/net/okocraft/box/feature/category/internal/listener/ItemInfoEventListener.java
+++ b/features/category/src/main/java/net/okocraft/box/feature/category/internal/listener/ItemInfoEventListener.java
@@ -2,6 +2,8 @@ package net.okocraft.box.feature.category.internal.listener;
 
 import com.github.siroshun09.event4j.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.event.player.PlayerCollectItemInfoEvent;
@@ -17,6 +19,9 @@ public class ItemInfoEventListener {
                     .append(Component.text(":"))
                     .color(NamedTextColor.GRAY)
                     .build();
+
+    private static final HoverEvent<Component> CLICK_TO_OPEN_MENU =
+            HoverEvent.showText(Component.translatable("box.category.item-info.click-to-open"));
 
     private final CategoryRegistry registry;
 
@@ -50,13 +55,14 @@ public class ItemInfoEventListener {
     }
 
     private @NotNull Component formatCategory(@NotNull Category category) {
-        var displayName =
+        return Component.space().append(
                 Component.text()
                         .append(Component.text("["))
                         .append(category.getDisplayName())
                         .append(Component.text("]"))
-                        .color(NamedTextColor.AQUA);
-
-        return Component.space().append(displayName);
+                        .color(NamedTextColor.AQUA)
+                        .hoverEvent(CLICK_TO_OPEN_MENU)
+                        .clickEvent(ClickEvent.runCommand("/box gui --category " + registry.getRegisteredName(category)))
+        );
     }
 }

--- a/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/command/MenuOpenCommand.java
+++ b/features/gui/src/main/java/net/okocraft/box/feature/gui/internal/command/MenuOpenCommand.java
@@ -3,15 +3,19 @@ package net.okocraft.box.feature.gui.internal.command;
 import net.kyori.adventure.text.Component;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.command.AbstractCommand;
+import net.okocraft.box.api.message.Components;
 import net.okocraft.box.api.message.GeneralMessage;
+import net.okocraft.box.api.message.argument.SingleArgument;
 import net.okocraft.box.api.model.stock.StockHolder;
 import net.okocraft.box.api.util.TabCompleter;
 import net.okocraft.box.api.util.UserStockHolderOperator;
+import net.okocraft.box.feature.category.api.registry.CategoryRegistry;
 import net.okocraft.box.feature.gui.api.event.MenuOpenEvent;
-import net.okocraft.box.api.message.Components;
+import net.okocraft.box.feature.gui.api.menu.Menu;
 import net.okocraft.box.feature.gui.api.mode.ClickModeRegistry;
 import net.okocraft.box.feature.gui.api.session.PlayerSession;
 import net.okocraft.box.feature.gui.api.util.MenuOpener;
+import net.okocraft.box.feature.gui.internal.menu.CategoryMenu;
 import net.okocraft.box.feature.gui.internal.menu.CategorySelectorMenu;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -19,13 +23,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 public class MenuOpenCommand extends AbstractCommand {
 
     private static final String OTHER_PLAYERS_GUI_PERMISSION = "box.admin.command.gui.other";
     private static final Component CANNOT_OPEN_MENU = Components.redTranslatable("box.gui.cannot-open-menu");
-    private static final Component COMMAND_HELP =Components.commandHelp("box.gui.command-help", false);
+    private static final Component COMMAND_HELP = Components.commandHelp("box.gui.command-help", false);
+    private static final SingleArgument<String> CATEGORY_NOT_FOUND = arg -> Components.redTranslatable("box.gui.category-not-found", Components.aquaText(arg));
 
     public MenuOpenCommand() {
         super("gui", "box.command.gui", Set.of("g", "menu", "m"));
@@ -38,43 +45,51 @@ public class MenuOpenCommand extends AbstractCommand {
             return;
         }
 
-        var session = PlayerSession.get(player);
-
-        session.setBoxItemClickMode(null);
-        session.resetCustomNumbers();
-
-        var modes = ClickModeRegistry.getModes().stream().filter(mode -> mode.canUse(player)).toList();
-        session.setAvailableClickModes(modes);
-
-        StockHolder stockHolder;
-
-        if (1 < args.length) {
-            if (!sender.hasPermission(OTHER_PLAYERS_GUI_PERMISSION)) {
-                sender.sendMessage(GeneralMessage.ERROR_NO_PERMISSION.apply(OTHER_PLAYERS_GUI_PERMISSION));
-                return;
-            }
-
-            stockHolder = UserStockHolderOperator.create(args[1]).supportOffline(true).getUserStockHolder();
-
-            if (stockHolder == null) {
-                sender.sendMessage(GeneralMessage.ERROR_COMMAND_PLAYER_NOT_FOUND.apply(args[1]));
-                return;
-            }
-        } else {
-            stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
-        }
-
-        session.setStockHolder(stockHolder);
-
-        var menu = new CategorySelectorMenu();
-        var event = new MenuOpenEvent(player, menu);
-
-        if (BoxProvider.get().getEventBus().callEvent(event).isCancelled()) {
-            sender.sendMessage(CANNOT_OPEN_MENU);
+        if (args.length < 2) {
+            openMenu(player, getCurrentStockHolder(player), new CategorySelectorMenu());
             return;
         }
 
-        MenuOpener.open(new CategorySelectorMenu(), player);
+        if (!args[1].startsWith("-")) {
+            legacyBehavior(player, args);
+            return;
+        }
+
+        StockHolder source = null;
+        Menu menu = null;
+
+        for (int i = 1; i + 1 < args.length; i = i + 2) {
+            var arg = args[i].toLowerCase(Locale.ENGLISH);
+
+            if (source == null && (arg.equalsIgnoreCase("-p") || arg.equalsIgnoreCase("--player"))) {
+                if (!player.hasPermission(OTHER_PLAYERS_GUI_PERMISSION)) {
+                    player.sendMessage(GeneralMessage.ERROR_NO_PERMISSION.apply(OTHER_PLAYERS_GUI_PERMISSION));
+                    return;
+                }
+
+                source = UserStockHolderOperator.create(args[i + 1]).supportOffline(true).getUserStockHolder();
+
+                if (source == null) {
+                    player.sendMessage(GeneralMessage.ERROR_COMMAND_PLAYER_NOT_FOUND.apply(args[i + 1]));
+                    return;
+                }
+            } else if (menu == null && (arg.equalsIgnoreCase("-c") || arg.equalsIgnoreCase("--category"))) {
+                var category = CategoryRegistry.get().getByName(args[i + 1]);
+
+                if (category.isEmpty()) {
+                    player.sendMessage(CATEGORY_NOT_FOUND.apply(args[i + 1]));
+                    return;
+                }
+
+                menu = new CategoryMenu(category.get());
+            }
+        }
+
+        openMenu(
+                player,
+                Objects.requireNonNullElseGet(source, () -> getCurrentStockHolder(player)),
+                Objects.requireNonNullElseGet(menu, CategorySelectorMenu::new)
+        );
     }
 
     @Override
@@ -84,10 +99,69 @@ public class MenuOpenCommand extends AbstractCommand {
 
     @Override
     public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
-        if (args.length == 2 && sender.hasPermission(OTHER_PLAYERS_GUI_PERMISSION)) {
-            return TabCompleter.players(args[1]);
-        } else {
+        if (args.length < 2 || !(sender instanceof Player)) {
             return Collections.emptyList();
         }
+
+        if (2 < args.length) {
+            var arg = args[args.length - 2].toLowerCase(Locale.ENGLISH);
+
+            if (arg.equalsIgnoreCase("-p") || arg.equalsIgnoreCase("--player")) {
+                return sender.hasPermission(OTHER_PLAYERS_GUI_PERMISSION) ?
+                        TabCompleter.players(args[args.length - 1]) :
+                        Collections.emptyList();
+            }
+
+            if (arg.equalsIgnoreCase("-c") || arg.equalsIgnoreCase("--category")) {
+                return CategoryRegistry.get().names()
+                        .stream()
+                        .filter(name -> name.startsWith(args[args.length - 1]))
+                        .toList();
+            }
+        }
+
+        return sender.hasPermission(OTHER_PLAYERS_GUI_PERMISSION) ?
+                List.of("--player", "--category", "-p", "-c") :
+                List.of("--category", "-c");
+    }
+
+    private void legacyBehavior(@NotNull Player player, @NotNull String[] args) {
+        if (!player.hasPermission(OTHER_PLAYERS_GUI_PERMISSION)) {
+            player.sendMessage(GeneralMessage.ERROR_NO_PERMISSION.apply(OTHER_PLAYERS_GUI_PERMISSION));
+            return;
+        }
+
+        var stockHolder = UserStockHolderOperator.create(args[1]).supportOffline(true).getUserStockHolder();
+
+        if (stockHolder == null) {
+            player.sendMessage(GeneralMessage.ERROR_COMMAND_PLAYER_NOT_FOUND.apply(args[1]));
+            return;
+        }
+
+        openMenu(player, stockHolder, new CategorySelectorMenu());
+    }
+
+    private void openMenu(@NotNull Player player, @NotNull StockHolder source, @NotNull Menu menu) {
+        var session = PlayerSession.get(player);
+
+        session.setBoxItemClickMode(null);
+        session.resetCustomNumbers();
+        session.setStockHolder(source);
+
+        var modes = ClickModeRegistry.getModes().stream().filter(mode -> mode.canUse(player)).toList();
+        session.setAvailableClickModes(modes);
+
+        var event = new MenuOpenEvent(player, menu);
+
+        if (BoxProvider.get().getEventBus().callEvent(event).isCancelled()) {
+            player.sendMessage(CANNOT_OPEN_MENU);
+            return;
+        }
+
+        MenuOpener.open(menu, player);
+    }
+
+    private @NotNull StockHolder getCurrentStockHolder(@NotNull Player player) { // Helper method
+        return BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
     }
 }


### PR DESCRIPTION
Waiting for merging #216 

## Change `/box gui` behavior

- `/box gui` - Opens the Box menu
- `/box gui <player name>` -> `/box gui --player <player name>` - Opens the Box menu with the specified player's stockholder
- `/box gui --category <category id>` - Opens the specified category menu

Note: `/box gui <player name>` can still be used, but will be removed in the future.

## Make the category name clickable in the item info

![image](https://github.com/okocraft/Box/assets/39247022/9fe3dbe1-3272-4b6e-9ddd-d0d07f34555e)