### PR TITLE
Add new methods to ItemManager

### DIFF
--- a/api/src/main/java/net/okocraft/box/api/model/item/BoxItem.java
+++ b/api/src/main/java/net/okocraft/box/api/model/item/BoxItem.java
@@ -10,6 +10,20 @@ import org.jetbrains.annotations.NotNull;
 public interface BoxItem {
 
     /**
+     * Gets the internal id of this item.
+     *
+     * @return the internal id of this id
+     */
+    int getInternalId();
+
+    /**
+     * Gets the plain name of this item.
+     *
+     * @return the plain name of this item
+     */
+    @NotNull String getPlainName();
+
+    /**
      * Gets the original {@link ItemStack}.
      * <p>
      * The item returned by this method must not be modified.
@@ -28,23 +42,9 @@ public interface BoxItem {
     @NotNull ItemStack getClonedItem();
 
     /**
-     * Gets the plain name of this item.
-     *
-     * @return the plain name of this item
-     */
-    @NotNull String getPlainName();
-
-    /**
      * Gets the display name of this item as a {@link Component}.
      *
      * @return the display name of this item as a {@link Component}
      */
     @NotNull Component getDisplayName();
-
-    /**
-     * Gets the internal id of this item.
-     *
-     * @return the internal id of this id
-     */
-    int getInternalId();
 }

--- a/api/src/main/java/net/okocraft/box/api/model/manager/ItemManager.java
+++ b/api/src/main/java/net/okocraft/box/api/model/manager/ItemManager.java
@@ -1,15 +1,21 @@
 package net.okocraft.box.api.model.manager;
 
+import it.unimi.dsi.fastutil.ints.IntImmutableList;
+import it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import net.okocraft.box.api.model.item.BoxCustomItem;
 import net.okocraft.box.api.model.item.BoxItem;
+import net.okocraft.box.api.model.result.item.ItemRegistrationResult;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * An interface to manage {@link BoxItem}s.
@@ -41,6 +47,39 @@ public interface ItemManager {
     @NotNull Optional<BoxItem> getBoxItem(int id);
 
     /**
+     * Gets the {@link BoxItem} of the specified id if it exists.
+     *
+     * @param id the id to get
+     * @return the {@link BoxItem} or null
+     */
+    @Nullable BoxItem getBoxItemOrNull(int id);
+
+    /**
+     * Gets a list of item ids.
+     * <p>
+     * This method returns a collection of {@link BoxItem#getInternalId()}.
+     *
+     * @return an immutable list of {@link BoxItem#getInternalId()}
+     */
+    @NotNull IntImmutableList getItemIdList();
+
+    /**
+     * Gets a list of item names
+     * <p>
+     * This method returns a collection of {@link BoxItem#getPlainName()}.
+     *
+     * @return an immutable list of {@link BoxItem#getPlainName()}
+     */
+    @NotNull ObjectImmutableList<String> getItemNameList();
+
+    /**
+     * Gets a list of registered {@link BoxItem}s.
+     *
+     * @return an immutable list of {@link BoxItem}s
+     */
+    @NotNull ObjectImmutableList<BoxItem> getItemList();
+
+    /**
      * Checks if the specified item has already been registered.
      *
      * @param itemStack the item to check
@@ -59,10 +98,29 @@ public interface ItemManager {
     /**
      * Checks if the specified item is a custom item created by box itself.
      *
-     * @param item  the item to check
+     * @param item the item to check
      * @return {@code true} if the item is a custom item, {@code false} otherwise
      */
     boolean isCustomItem(@NotNull BoxItem item);
+
+    /**
+     * Registers a new item.
+     *
+     * @param original       the item to register
+     * @param plainName      the name of the item
+     * @param resultConsumer a {@link Consumer}, which will be called when completed registration process
+     */
+    void registerCustomItem(@NotNull ItemStack original, @Nullable String plainName, @NotNull Consumer<ItemRegistrationResult> resultConsumer);
+
+    /**
+     * Renames a {@link BoxCustomItem}.
+     *
+     * @param item           a {@link BoxCustomItem} to rename
+     * @param newName        a new name
+     * @param resultConsumer a {@link Consumer}, which will be called when completed registration process
+     * @throws IllegalArgumentException {@link BoxCustomItem} is not created by Box ({@link #isCustomItem(BoxItem)} returns {@code false})
+     */
+    void renameCustomItem(@NotNull BoxCustomItem item, @NotNull String newName, @NotNull Consumer<ItemRegistrationResult> resultConsumer);
 
     /**
      * Registers item.
@@ -72,8 +130,29 @@ public interface ItemManager {
      *
      * @param original the item to register
      * @return the {@link CompletableFuture} to register item
+     * @deprecated use {@link #registerCustomItem(ItemStack, String, Consumer)}
      */
-    @NotNull CompletableFuture<@NotNull BoxCustomItem> registerCustomItem(@NotNull ItemStack original);
+    @Deprecated(forRemoval = true, since = "5.5.0")
+    @ApiStatus.ScheduledForRemoval(inVersion = "6.0.0")
+    default @NotNull CompletableFuture<@NotNull BoxCustomItem> registerCustomItem(@NotNull ItemStack original) {
+        var future = new CompletableFuture<BoxCustomItem>();
+
+        registerCustomItem(
+                original,
+                null,
+                result -> {
+                    if (result instanceof ItemRegistrationResult.Success success) {
+                        future.complete(success.customItem());
+                    } else if (result instanceof ItemRegistrationResult.DuplicateItem duplicateItem) {
+                        future.completeExceptionally(new IllegalStateException("The item is already registered (item: " + duplicateItem.item() + ")"));
+                    } else if (result instanceof ItemRegistrationResult.ExceptionOccurred exceptionOccurred) {
+                        future.completeExceptionally(exceptionOccurred.exception());
+                    }
+                }
+        );
+
+        return future;
+    }
 
     /**
      * Rename the custom item.
@@ -81,9 +160,34 @@ public interface ItemManager {
      * @param item    the custom item to rename
      * @param newName the new name
      * @return the {@link CompletableFuture} to rename an item
+     * @deprecated use {@link #renameCustomItem(BoxCustomItem, String, Consumer)}
      */
-    @NotNull CompletableFuture<@NotNull BoxCustomItem> renameCustomItem(@NotNull BoxCustomItem item,
-                                                                        @NotNull String newName);
+    @Deprecated(forRemoval = true, since = "5.5.0")
+    @ApiStatus.ScheduledForRemoval(inVersion = "6.0.0")
+    default @NotNull CompletableFuture<@NotNull BoxCustomItem> renameCustomItem(@NotNull BoxCustomItem item, @NotNull String newName) {
+        var future = new CompletableFuture<BoxCustomItem>();
+
+        if (!isCustomItem(item)) {
+            future.completeExceptionally(new IllegalStateException("Could not rename item because the item is created by box."));
+            return future;
+        }
+
+        renameCustomItem(
+                item,
+                newName,
+                result -> {
+                    if (result instanceof ItemRegistrationResult.Success success) {
+                        future.complete(success.customItem());
+                    } else if (result instanceof ItemRegistrationResult.DuplicateName duplicateName) {
+                        future.completeExceptionally(new IllegalStateException("The name is already used (name: " + duplicateName.name() + ")"));
+                    } else if (result instanceof ItemRegistrationResult.ExceptionOccurred exceptionOccurred) {
+                        future.completeExceptionally(exceptionOccurred.exception());
+                    }
+                }
+        );
+
+        return future;
+    }
 
     /**
      * Gets the item name set.
@@ -91,13 +195,19 @@ public interface ItemManager {
      * Returns set is a collection of {@link BoxItem#getPlainName()}.
      *
      * @return the set of {@link BoxItem#getPlainName()}
+     * @deprecated use {@link #getItemNameList()}
      */
+    @Deprecated(forRemoval = true, since = "5.5.0")
+    @ApiStatus.ScheduledForRemoval(inVersion = "6.0.0")
     @NotNull @Unmodifiable Set<String> getItemNameSet();
 
     /**
      * Gets all {@link BoxItem}s.
      *
      * @return the set of all {@link BoxItem}s
+     * @deprecated use {@link #getItemList()}
      */
+    @Deprecated(forRemoval = true, since = "5.5.0")
+    @ApiStatus.ScheduledForRemoval(inVersion = "6.0.0")
     @NotNull @Unmodifiable Collection<BoxItem> getBoxItemSet();
 }

--- a/api/src/main/java/net/okocraft/box/api/model/result/item/ItemRegistrationResult.java
+++ b/api/src/main/java/net/okocraft/box/api/model/result/item/ItemRegistrationResult.java
@@ -1,0 +1,21 @@
+package net.okocraft.box.api.model.result.item;
+
+import net.okocraft.box.api.model.item.BoxCustomItem;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public sealed interface ItemRegistrationResult permits ItemRegistrationResult.DuplicateItem, ItemRegistrationResult.DuplicateName, ItemRegistrationResult.ExceptionOccurred, ItemRegistrationResult.Success {
+
+    record Success(@NotNull BoxCustomItem customItem) implements ItemRegistrationResult {
+    }
+
+    record DuplicateName(@NotNull String name) implements ItemRegistrationResult {
+    }
+
+    record DuplicateItem(@NotNull ItemStack item) implements ItemRegistrationResult {
+    }
+
+    record ExceptionOccurred(@NotNull Exception exception) implements ItemRegistrationResult {
+    }
+
+}

--- a/api/src/main/java/net/okocraft/box/api/util/TabCompleter.java
+++ b/api/src/main/java/net/okocraft/box/api/util/TabCompleter.java
@@ -22,12 +22,12 @@ public final class TabCompleter {
      * @return the list of item names that match the filter
      */
     public static @NotNull List<String> itemNames(@NotNull String filter) {
-        var itemNameFilter = filter.toUpperCase(Locale.ENGLISH);
+        var itemNameFilter = filter.toLowerCase(Locale.ENGLISH);
         return BoxProvider.get()
                 .getItemManager()
                 .getItemNameList()
                 .stream()
-                .filter(itemName -> itemName.startsWith(itemNameFilter))
+                .filter(itemName -> itemName.toLowerCase(Locale.ENGLISH).startsWith(itemNameFilter))
                 .collect(Collectors.toList());
     }
 

--- a/api/src/main/java/net/okocraft/box/api/util/TabCompleter.java
+++ b/api/src/main/java/net/okocraft/box/api/util/TabCompleter.java
@@ -25,7 +25,7 @@ public final class TabCompleter {
         var itemNameFilter = filter.toUpperCase(Locale.ENGLISH);
         return BoxProvider.get()
                 .getItemManager()
-                .getItemNameSet()
+                .getItemNameList()
                 .stream()
                 .filter(itemName -> itemName.startsWith(itemNameFilter))
                 .collect(Collectors.toList());

--- a/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
+++ b/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
@@ -149,6 +149,8 @@ public class BoxItemManager implements ItemManager {
                 return;
             }
 
+            addItem(item);
+
             BoxProvider.get().getEventBus().callEventAsync(new CustomItemRenameEvent(result, previousName));
             resultConsumer.accept(new ItemRegistrationResult.Success(result));
         });

--- a/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
+++ b/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -49,8 +48,7 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public @NotNull Optional<BoxItem> getBoxItem(@NotNull String name) {
-        name = Objects.requireNonNull(name).toUpperCase(Locale.ROOT);
-        return Optional.ofNullable(itemNameMap.get(name));
+        return Optional.ofNullable(itemNameMap.get(Objects.requireNonNull(name)));
     }
 
     @Override

--- a/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
+++ b/core/src/main/java/net/okocraft/box/core/model/manager/BoxItemManager.java
@@ -1,29 +1,32 @@
 package net.okocraft.box.core.model.manager;
 
+import it.unimi.dsi.fastutil.ints.IntImmutableList;
+import it.unimi.dsi.fastutil.objects.ObjectImmutableList;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.event.item.CustomItemRegisterEvent;
 import net.okocraft.box.api.event.item.CustomItemRenameEvent;
 import net.okocraft.box.api.model.item.BoxCustomItem;
 import net.okocraft.box.api.model.item.BoxItem;
 import net.okocraft.box.api.model.manager.ItemManager;
+import net.okocraft.box.api.model.result.item.ItemRegistrationResult;
 import net.okocraft.box.core.util.executor.InternalExecutors;
 import net.okocraft.box.storage.api.factory.item.BoxItemFactory;
 import net.okocraft.box.storage.api.model.item.ItemStorage;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 public class BoxItemManager implements ItemManager {
 
@@ -56,6 +59,26 @@ public class BoxItemManager implements ItemManager {
     }
 
     @Override
+    public @Nullable BoxItem getBoxItemOrNull(int id) {
+        return itemIdMap.get(id);
+    }
+
+    @Override
+    public @NotNull IntImmutableList getItemIdList() {
+        return new IntImmutableList(itemIdMap.keySet());
+    }
+
+    @Override
+    public @NotNull ObjectImmutableList<String> getItemNameList() {
+        return new ObjectImmutableList<>(itemNameMap.keySet());
+    }
+
+    @Override
+    public @NotNull ObjectImmutableList<BoxItem> getItemList() {
+        return new ObjectImmutableList<>(itemIdMap.values());
+    }
+
+    @Override
     public boolean isRegistered(@NotNull ItemStack itemStack) {
         return itemMap.containsKey(itemStack.asOne());
     }
@@ -73,45 +96,47 @@ public class BoxItemManager implements ItemManager {
     }
 
     @Override
-    public @NotNull CompletableFuture<@NotNull BoxCustomItem> registerCustomItem(@NotNull ItemStack original) {
-        Objects.requireNonNull(original);
+    public void registerCustomItem(@NotNull ItemStack original, @Nullable String plainName, @NotNull Consumer<ItemRegistrationResult> resultConsumer) {
+        var one = original.asOne();
+        Objects.requireNonNull(resultConsumer);
 
-        return CompletableFuture.supplyAsync(() -> {
-            var copied = original.asOne();
+        executor.execute(() -> {
+            if (isRegistered(one)) {
+                resultConsumer.accept(new ItemRegistrationResult.DuplicateItem(one));
+                return;
+            }
 
-            if (isRegistered(copied)) {
-                throw new IllegalStateException("The item is already registered (item: " + copied + ")");
+            if (plainName != null && isUsedName(plainName)) {
+                resultConsumer.accept(new ItemRegistrationResult.DuplicateName(plainName));
+                return;
             }
 
             BoxCustomItem customItem;
 
             try {
-                customItem = itemStorage.saveNewCustomItem(copied);
+                customItem = itemStorage.saveNewCustomItem(one, plainName);
             } catch (Exception e) {
-                throw new RuntimeException("Could not register a new item (item: " + copied + ")", e);
+                resultConsumer.accept(new ItemRegistrationResult.ExceptionOccurred(e));
+                return;
             }
 
             addItem(customItem);
 
             BoxProvider.get().getEventBus().callEventAsync(new CustomItemRegisterEvent(customItem));
-
-            return customItem;
-        }, executor);
+            resultConsumer.accept(new ItemRegistrationResult.Success(customItem));
+        });
     }
 
     @Override
-    public @NotNull CompletableFuture<@NotNull BoxCustomItem> renameCustomItem(@NotNull BoxCustomItem item,
-                                                                               @NotNull String newName) {
-        Objects.requireNonNull(item);
-        Objects.requireNonNull(newName);
+    public void renameCustomItem(@NotNull BoxCustomItem item, @NotNull String newName, @NotNull Consumer<ItemRegistrationResult> resultConsumer) {
+        if (!BoxItemFactory.checkCustomItem(item)) {
+            throw new IllegalArgumentException("Could not rename item because the item is not created by box.");
+        }
 
-        return CompletableFuture.supplyAsync(() -> {
-            if (!BoxItemFactory.checkCustomItem(item)) {
-                throw new IllegalStateException("Could not rename item because the item is created by box.");
-            }
-
+        executor.execute(() -> {
             if (itemNameMap.containsKey(newName)) {
-                throw new IllegalStateException("The same name is already used (" + newName + ")");
+                resultConsumer.accept(new ItemRegistrationResult.DuplicateName(newName));
+                return;
             }
 
             removeItem(item);
@@ -122,13 +147,13 @@ public class BoxItemManager implements ItemManager {
             try {
                 result = itemStorage.rename(item, newName);
             } catch (Exception e) {
-                throw new RuntimeException("Could not save the custom item", e);
+                resultConsumer.accept(new ItemRegistrationResult.ExceptionOccurred(e));
+                return;
             }
 
             BoxProvider.get().getEventBus().callEventAsync(new CustomItemRenameEvent(result, previousName));
-
-            return result;
-        }, executor);
+            resultConsumer.accept(new ItemRegistrationResult.Success(result));
+        });
     }
 
     @Override
@@ -138,7 +163,7 @@ public class BoxItemManager implements ItemManager {
 
     @Override
     public @NotNull @Unmodifiable Collection<BoxItem> getBoxItemSet() {
-        return List.copyOf(itemMap.values());
+        return getItemList();
     }
 
     public void storeItems(@NotNull Collection<? extends BoxItem> items) {

--- a/features/autostore/src/main/java/net/okocraft/box/feature/autostore/command/AutoStoreItemCommand.java
+++ b/features/autostore/src/main/java/net/okocraft/box/feature/autostore/command/AutoStoreItemCommand.java
@@ -52,7 +52,7 @@ class AutoStoreItemCommand extends AutoStoreSubCommand {
             AutoStoreCommandUtil.enableAutoStore(setting, sender);
             changeToPerItemMode(setting, sender);
 
-            perItemModeSetting.setEnabledItems(bool ? itemManager.getBoxItemSet() : Collections.emptyList());
+            perItemModeSetting.setEnabledItems(bool ? itemManager.getItemList() : Collections.emptyList());
             sender.sendMessage(AutoStoreMessage.COMMAND_PER_ITEM_ALL_TOGGLED.apply(bool));
 
             AutoStoreCommandUtil.callEvent(setting);

--- a/features/autostore/src/main/java/net/okocraft/box/feature/autostore/command/AutoStoreItemCommand.java
+++ b/features/autostore/src/main/java/net/okocraft/box/feature/autostore/command/AutoStoreItemCommand.java
@@ -98,7 +98,7 @@ class AutoStoreItemCommand extends AutoStoreSubCommand {
     @Override
     @NotNull List<String> runTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
         if (args.length == 3) {
-            var result = TabCompleter.itemNames(args[2].toUpperCase(Locale.ROOT));
+            var result = TabCompleter.itemNames(args[2]);
 
             if ("all".startsWith(args[2].toLowerCase(Locale.ROOT))) {
                 result.add("all");

--- a/features/autostore/src/main/java/net/okocraft/box/feature/autostore/gui/buttons/BulkEditingButton.java
+++ b/features/autostore/src/main/java/net/okocraft/box/feature/autostore/gui/buttons/BulkEditingButton.java
@@ -61,7 +61,7 @@ public class BulkEditingButton extends AbstractAutoStoreSettingButton {
         Sound sound;
 
         if (recent == null || !recent) {
-            perItemSetting.setEnabledItems(BoxProvider.get().getItemManager().getBoxItemSet());
+            perItemSetting.setEnabledItems(BoxProvider.get().getItemManager().getItemList());
             sound = Sound.BLOCK_WOODEN_DOOR_OPEN;
             recent = true;
         } else {

--- a/features/category/src/main/java/net/okocraft/box/feature/category/internal/file/CategoryLoader.java
+++ b/features/category/src/main/java/net/okocraft/box/feature/category/internal/file/CategoryLoader.java
@@ -27,7 +27,7 @@ public final class CategoryLoader {
 
     public static void load(@NotNull CategoryRegistry registry, @NotNull Configuration source) {
         var itemManager = BoxProvider.get().getItemManager();
-        var uncategorizedItems = new HashSet<>(itemManager.getBoxItemSet());
+        var uncategorizedItems = new HashSet<>(itemManager.getItemList());
 
         for (var key : source.getKeyList()) {
             if (key.equals("icons") ||

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/DepositCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/DepositCommand.java
@@ -183,7 +183,7 @@ public class DepositCommand extends AbstractCommand {
         }
 
         if (args.length == 2) {
-            var itemNameFilter = args[1].toUpperCase(Locale.ROOT);
+            var itemNameFilter = args[1].toLowerCase(Locale.ENGLISH);
 
             //noinspection ConstantConditions
             var result =
@@ -193,10 +193,10 @@ public class DepositCommand extends AbstractCommand {
                             .filter(Optional::isPresent)
                             .map(Optional::get)
                             .map(BoxItem::getPlainName)
-                            .filter(itemName -> itemName.startsWith(itemNameFilter))
+                            .filter(itemName -> itemName.toLowerCase(Locale.ENGLISH).startsWith(itemNameFilter))
                             .collect(Collectors.toList());
 
-            if ("all".startsWith(args[1].toLowerCase(Locale.ROOT))) {
+            if ("all".startsWith(args[1].toLowerCase(Locale.ENGLISH))) {
                 result.add("all");
             }
 

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/GiveCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/GiveCommand.java
@@ -122,12 +122,12 @@ public class GiveCommand extends AbstractCommand {
         }
 
         if (args.length == 3) {
-            var itemNameFilter = args[2].toUpperCase(Locale.ROOT);
+            var itemNameFilter = args[2].toLowerCase(Locale.ENGLISH);
             var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
 
             return stockHolder.getStockedItems().stream()
                     .map(BoxItem::getPlainName)
-                    .filter(itemName -> itemName.startsWith(itemNameFilter))
+                    .filter(itemName -> itemName.toLowerCase(Locale.ENGLISH).startsWith(itemNameFilter))
                     .collect(Collectors.toList());
         }
 

--- a/features/command/src/main/java/net/okocraft/box/feature/command/box/WithdrawCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/box/WithdrawCommand.java
@@ -95,7 +95,7 @@ public class WithdrawCommand extends AbstractCommand {
             return Collections.emptyList();
         }
 
-        var itemNameFilter = args[1].toUpperCase(Locale.ROOT);
+        var itemNameFilter = args[1].toLowerCase(Locale.ENGLISH);
         var stockHolder = BoxProvider.get().getBoxPlayerMap().get(player).getCurrentStockHolder();
 
         return stockHolder.getStockedItems().stream()

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/InfinityCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/InfinityCommand.java
@@ -132,7 +132,7 @@ public class InfinityCommand extends AbstractCommand {
 
         @Override
         public @NotNull @Unmodifiable Collection<BoxItem> getStockedItems() {
-            return BoxProvider.get().getItemManager().getBoxItemSet();
+            return BoxProvider.get().getItemManager().getItemList();
         }
 
         @Override

--- a/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/RegisterCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/boxadmin/RegisterCommand.java
@@ -4,10 +4,13 @@ import net.kyori.adventure.text.Component;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.command.AbstractCommand;
 import net.okocraft.box.api.message.GeneralMessage;
+import net.okocraft.box.api.model.result.item.ItemRegistrationResult;
 import net.okocraft.box.feature.command.message.BoxAdminMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.logging.Level;
 
 public class RegisterCommand extends AbstractCommand {
 
@@ -29,26 +32,30 @@ public class RegisterCommand extends AbstractCommand {
             return;
         }
 
-        var itemManager = BoxProvider.get().getItemManager();
-
-        if (itemManager.isRegistered(mainHandItem)) {
-            player.sendMessage(BoxAdminMessage.REGISTER_ALREADY_REGISTERED.apply(mainHandItem));
-            return;
-        }
-
-        itemManager.registerCustomItem(mainHandItem)
-                .thenAcceptAsync(customItem -> {
-                    player.sendMessage(BoxAdminMessage.REGISTER_SUCCESS.apply(customItem));
-                    player.sendMessage(BoxAdminMessage.REGISTER_TIP_RENAME);
-                })
-                .exceptionallyAsync(e -> {
-                    player.sendMessage(BoxAdminMessage.REGISTER_FAILURE.apply(e));
-                    return null;
-                });
+        BoxProvider.get().getItemManager().registerCustomItem(
+                mainHandItem,
+                1 < args.length ? args[1] : null,
+                result -> consumeResult(player, result)
+        );
     }
 
     @Override
     public @NotNull Component getHelp() {
         return BoxAdminMessage.REGISTER_HELP;
+    }
+
+    private void consumeResult(@NotNull Player player, @NotNull ItemRegistrationResult result) {
+        if (result instanceof ItemRegistrationResult.Success success) {
+            player.sendMessage(BoxAdminMessage.REGISTER_SUCCESS.apply(success.customItem()));
+            player.sendMessage(BoxAdminMessage.REGISTER_TIP_RENAME);
+        } else if (result instanceof ItemRegistrationResult.DuplicateName duplicateName) {
+            player.sendMessage(BoxAdminMessage.RENAME_ALREADY_USED_NAME.apply(duplicateName.name()));
+        } else if (result instanceof ItemRegistrationResult.DuplicateItem duplicateItem) {
+            player.sendMessage(BoxAdminMessage.REGISTER_ALREADY_REGISTERED.apply(duplicateItem.item()));
+        } else if (result instanceof ItemRegistrationResult.ExceptionOccurred exceptionOccurred) {
+            var ex = exceptionOccurred.exception();
+            player.sendMessage(BoxAdminMessage.REGISTER_FAILURE.apply(ex));
+            BoxProvider.get().getLogger().log(Level.SEVERE, "Could not register a new custom item.", ex);
+        }
     }
 }

--- a/features/command/src/main/java/net/okocraft/box/feature/command/shared/SharedStockListCommand.java
+++ b/features/command/src/main/java/net/okocraft/box/feature/command/shared/SharedStockListCommand.java
@@ -129,34 +129,34 @@ public class SharedStockListCommand {
         boolean endsWith = arg.startsWith("*");
 
         if (startsWith && endsWith) {
-            var filter = arg.substring(1, arg.length() - 1).toUpperCase(Locale.ROOT);
+            var filter = arg.substring(1, arg.length() - 1).toLowerCase(Locale.ENGLISH);
             return item -> contains(item, filter);
         }
 
         if (startsWith) {
-            var filter = arg.substring(0, arg.length() - 1).toUpperCase(Locale.ROOT);
+            var filter = arg.substring(0, arg.length() - 1).toLowerCase(Locale.ENGLISH);
             return item -> startsWith(item, filter);
         }
 
         if (endsWith) {
-            var filter = arg.substring(1).toUpperCase(Locale.ROOT);
+            var filter = arg.substring(1).toLowerCase(Locale.ENGLISH);
             return item -> endsWith(item, filter);
         }
 
-        var filter = arg.toUpperCase(Locale.ROOT);
+        var filter = arg.toLowerCase(Locale.ENGLISH);
         return item -> contains(item, filter);
     }
 
     private static boolean startsWith(@NotNull BoxItem item, @NotNull String filter) {
-        return item.getPlainName().startsWith(filter);
+        return item.getPlainName().toLowerCase(Locale.ENGLISH).startsWith(filter);
     }
 
     private static boolean endsWith(@NotNull BoxItem item, @NotNull String filter) {
-        return item.getPlainName().endsWith(filter);
+        return item.getPlainName().toLowerCase(Locale.ENGLISH).endsWith(filter);
     }
 
     private static boolean contains(@NotNull BoxItem item, @NotNull String filter) {
-        return item.getPlainName().contains(filter);
+        return item.getPlainName().toLowerCase(Locale.ENGLISH).contains(filter);
     }
 
     private static final class Context {

--- a/features/craft/src/main/java/net/okocraft/box/feature/craft/command/CraftCommand.java
+++ b/features/craft/src/main/java/net/okocraft/box/feature/craft/command/CraftCommand.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.okocraft.box.api.BoxProvider;
 import net.okocraft.box.api.command.AbstractCommand;
 import net.okocraft.box.api.message.GeneralMessage;
+import net.okocraft.box.api.util.TabCompleter;
 import net.okocraft.box.feature.craft.RecipeRegistry;
 import net.okocraft.box.feature.craft.lang.Displays;
 import net.okocraft.box.feature.craft.menu.CraftMenu;
@@ -17,9 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class CraftCommand extends AbstractCommand {
 
@@ -72,17 +71,11 @@ public class CraftCommand extends AbstractCommand {
 
     @Override
     public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
-        if (!(sender instanceof Player) || args.length != 2) {
+        if (sender instanceof Player && args.length == 2) {
+            return TabCompleter.itemNames(args[1]);
+        } else {
             return Collections.emptyList();
         }
-
-        var itemNameFilter = args[1].toUpperCase(Locale.ROOT);
-        return BoxProvider.get()
-                .getItemManager()
-                .getItemNameSet()
-                .stream()
-                .filter(itemName -> itemName.startsWith(itemNameFilter))
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/storage/api/src/main/java/net/okocraft/box/storage/api/util/item/ItemNameGenerator.java
+++ b/storage/api/src/main/java/net/okocraft/box/storage/api/util/item/ItemNameGenerator.java
@@ -2,9 +2,9 @@ package net.okocraft.box.storage.api.util.item;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 public final class ItemNameGenerator {
 
@@ -12,7 +12,7 @@ public final class ItemNameGenerator {
         var sha1 = getSha1();
         sha1.reset();
         var result = sha1.digest(itemBytes);
-        return itemType + "_" + String.format("%040x", new BigInteger(0, result)).substring(0, 8);
+        return itemType + "_" + HexFormat.of().withLowerCase().formatHex(result).substring(0, 8);
     }
 
     private static @NotNull MessageDigest getSha1() {


### PR DESCRIPTION
- Add `getBoxItemOrNull`, `getItemIdList`, `getItemNameList` and `getItemList` to `ItemManager`
- Add `ItemRegistrationResult` and add methods that use it to `ItemManager`
  - Old `registerCustomItem` and `renameCustomItem` have been deprecated
- Item name is no longer always uppercase

This PR is for preparing for v6, which will include changes in the `refactor/item` branch.
